### PR TITLE
Handle negated words with uppercase letters

### DIFF
--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -32,6 +32,7 @@ class Analyzer
     */
     public function IsNegated($wordToTest, $include_nt = true)
     {
+        $wordToTest = strtolower($wordToTest);
         if (in_array($wordToTest, Config::NEGATE)) {
             return true;
         }


### PR DESCRIPTION
Convert words that are being tested for negation to lowercase before performing the test. This way, we can keep all lowercase words in the negated word lexicon, and be sure that the tested word will be properly detected as a negated word regardless of its case.

Here is a comparison of results created before and after this change:

#### `Not good`

Before:
```json
{"neg":0,"neu":0.256,"pos":0.744,"compound":0.4404}
```
After:
```json
{"neg":0.609,"neu":0.391,"pos":0,"compound":-0.1423}
```

#### `not good`

Before:
```json
{"neg":0.609,"neu":0.391,"pos":0,"compound":-0.1423}
```
After:
```json
{"neg":0.609,"neu":0.391,"pos":0,"compound":-0.1423}
```

#### `Not great`

Before:
```json
{"neg":0,"neu":0.196,"pos":0.804,"compound":0.6249}
```
After:
```json
{"neg":0.656,"neu":0.344,"pos":0,"compound":-0.2283}
```

#### `not great`

Before:
```json
{"neg":0.656,"neu":0.344,"pos":0,"compound":-0.2283}
```
After:
```json
{"neg":0.656,"neu":0.344,"pos":0,"compound":-0.2283}
```


As you can see, the results of the sentences with capitalized negations and with non-capitalized negations are now the same.