### PR TITLE
Correct the VADER claim and make conformance measurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project are documented here.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [2.0.1] - 2026-08-20
+
+### Scores are unchanged
+
+Documentation and tooling only. No source file was modified and every pinned
+score is byte-identical to 2.0.0. **No need to re-score stored text.**
+
+### Changed
+
+- **Corrected the package description.** It previously read "…using VADER
+  (Valence Aware Dictionary and sentiment Reasoner)", which implied score
+  equivalence with the reference Python implementation. Measurement shows scores
+  differ on 47% of a 336-case corpus, so the claim is now scoped to what is
+  provably true: the package is *built on the VADER sentiment lexicon*, which it
+  uses verbatim.
+
+### Added
+
+- **`composer conformance`** (`tools/conformance.sh`) — a three-way comparison of
+  this package's 1.x line, its 2.x line, and reference Python `vaderSentiment`,
+  reporting divergence per rule section. Informational; it does not gate CI.
+- A **"Relationship to VADER"** section in the README, and a new section 0 in
+  `KNOWN-DIVERGENCES.md` documenting the measured divergence and its causes —
+  chiefly negation being ~2.5x too weak and booster damping being applied in
+  reverse order.
+
+### Fixed — documentation
+
+- `KNOWN-DIVERGENCES.md` section 2 previously claimed "15 of 21 idioms do not
+  fire", measured against the idiom tables. That framing was incorrect: reference
+  VADER only consults idioms in specific positions, and `SENTIMENT_LADEN_IDIOMS`
+  is explicitly unimplemented upstream, so most of those cases were parity rather
+  than defects. Rewritten against reference behaviour.
+
 ## [2.0.0] - 2026-08-19
 
 ### Scores are unchanged

--- a/KNOWN-DIVERGENCES.md
+++ b/KNOWN-DIVERGENCES.md
@@ -18,6 +18,82 @@ This file is the worklist for the post-2.0 scoring-fix release.
 
 ---
 
+## 0. Conformance with reference VADER — 47% of cases differ
+
+The package implements VADER's rule model but is **not score-equivalent** with
+the reference Python implementation. Measured with `composer conformance`
+against Python `vaderSentiment` 3.3.2 over 336 corpus cases:
+
+| Section | v1 differs | v2 differs | v1 vs v2 | total |
+|---|---|---|---|---|
+| booster | 70 | 70 | 0 | 70 |
+| negation | 59 | 59 | 0 | 59 |
+| idiom | 7 | 7 | 0 | 21 |
+| least_never | 5 | 5 | 0 | 8 |
+| never_check | 5 | 5 | 0 | 14 |
+| kind_of | 4 | 4 | 0 | 4 |
+| caps | 2 | 2 | 0 | 8 |
+| edge | 2 | 2 | 0 | 18 |
+| idiom_sentence | 2 | 2 | 0 | 21 |
+| punctuation | 2 | 2 | 0 | 12 |
+| but_clause | 0 | 0 | 0 | 8 |
+| emoji | 0 | 0 | 0 | 25 |
+| emoji_sentence | 0 | 0 | 0 | 25 |
+| lexicon | 0 | 0 | 0 | 40 |
+| readme | 0 | 0 | 0 | 3 |
+| **TOTAL** | **158** | **158** | **0** | **336** |
+
+Two observations before the causes.
+
+**The dictionary half is exact.** All 40 lexicon lookups, 50 emoji cases, 8
+but-clause cases and the 3 README examples match reference precisely. The
+lexicon files are byte-identical to upstream.
+
+**v1 and v2 agree on every case.** The divergence is inherited from the original
+port; the 2.0.0 modernization introduced none of it. That column is also a
+regression alarm — a non-zero value means the two release lines have drifted.
+
+### Cause 1 — negation is ~2.5x too weak
+
+`_never_check()` multiplies by `B_DECR (-0.293)` where reference uses
+`N_SCALAR (-0.74)`.
+
+```
+"aint good"    this package: -0.1423     reference: -0.3412
+```
+
+Because every negated phrase is scaled by roughly a third of the intended
+amount, the package **systematically under-detects negative sentiment**. This is
+the single highest-impact divergence: it affects all 59 negation cases.
+
+### Cause 2 — booster damping is inverted
+
+`getWordInContext()` returns `[i-3, i-2, i-1, i]`, but the distance damping
+(none / x0.95 / x0.9) is applied by array position. The result is that the
+*nearest* modifier is damped most and the *most distant* not at all — the
+opposite of the intent.
+
+```
+"very good"    this package: 0.4877      reference: 0.4927
+```
+
+### Cause 3 — "never so/this" flips sign
+
+Reference treats `never so` / `never this` as an intensifier (x1.25 / x1.5)
+without negating. The port negates as well, which can invert the sign of an
+ordinary sentence:
+
+```
+"I have never been so happy"    this package: -0.2699    reference: +0.6948
+```
+
+### Status
+
+**Not scheduled.** Correcting these would move roughly half of all scores, which
+is a major-version change for a package with a substantial install base. It is
+documented here, measurable via `composer conformance`, and deliberately left
+alone rather than fixed piecemeal.
+
 ## 1. `_never_check` zeroed sentiment after "so" or "this" — FIXED in 1.3.0
 
 `Analyzer::_never_check()` initialised `$neverModifier` to `0` and then applied
@@ -47,43 +123,44 @@ still score -0.2385 and -0.2108. No other pinned case moved.
 **This is the one deliberate scoring change in the 1.x line.** Everything below
 remains pinned as-is.
 
-## 2. 15 of 21 idioms do not fire
+## 2. Idioms rarely fire — mostly matching reference
 
-`_idioms_check()` scores the constituent words instead of the idiom. Nine never
-match at all; six resolve with the **opposite sign** to their own table value in
-`src/Config/Config.php:56` and `:63`.
+An earlier version of this file claimed "15 of 21 idioms do not fire" and
+measured each idiom against its value in `src/Config/Config.php`. **That framing
+was wrong**, and it is corrected here.
 
-| Idiom | Table | Pinned | Failure |
-|---|---|---|---|
-| `bad ass` | +1.5 | -0.2500 | sign inverted |
-| `yeah right` | -2.0 | 0.2960 | sign inverted |
-| `cut the mustard` | +2.0 | -0.2732 | sign inverted |
-| `kiss of death` | -1.5 | 0.0772 | sign inverted |
-| `hand to mouth` | -2.0 | 0.4939 | sign inverted |
-| `to die for` | +3.0 | -0.5994 | sign inverted |
-| `back handed` | -2.0 | 0.0000 | never matches |
-| `blow smoke` | -2.0 | 0.0000 | never matches |
-| `blowing smoke` | -2.0 | 0.0000 | never matches |
-| `break a leg` | +2.0 | 0.0000 | never matches |
-| `cooking with gas` | +2.0 | 0.0000 | never matches |
-| `in the black` | +2.0 | 0.0000 | never matches |
-| `in the red` | -2.0 | 0.0000 | never matches |
-| `on the ball` | +2.0 | 0.0000 | never matches |
-| `under the weather` | -2.0 | 0.0000 | never matches |
+The idiom tables were never the contract. Reference VADER gates
+`_special_idioms_check()` on `start_i == 2`, so an idiom is only consulted when
+the sentiment word sits at index >= 3 with a non-lexicon word three positions
+back. Short phrases therefore never trigger it — in reference VADER itself:
 
-The six that resolve with the right sign: `the shit` (+3.0 → 0.6124),
-`the bomb` (+3.0 → 0.6124), `beating heart` (+3.1 → 0.2732), `broken heart`
-(-2.9 → -0.7906), `upper hand` (+1.0 → 0.4939), and `bus stop` (0.0 → 0.0000,
-which only agrees trivially because its table value is zero).
+```
+"bad ass"              reference: -0.7906   (idiom value +1.5 not applied)
+"the shit"             reference: -0.5574   (idiom value +3 not applied)
+"it was a bad ass"     reference: +0.6124   (idiom applied)
+```
 
-Corpus sections: `idiom/*`, `idiom_sentence/*`.
+So "the idiom didn't fire" is usually correct behaviour, not a defect.
 
-**Note for v2:** this constrains custom lexicons. Multi-word keys passed to
-`withLexicon()` would land in the term lexicon, not the idiom table, so they
-cannot work until the idiom matcher does — which is why `withLexicon()` rejects
-them outright rather than accepting them and doing nothing.
+**`SENTIMENT_LADEN_IDIOMS` is unimplemented on purpose.** Upstream marks it
+*"future work, not yet implemented"*, never calls its own
+`_sentiment_laden_idioms_check()`, and leaves a debug `print()` inside it. The
+9 laden-only idioms (`under the weather`, `break a leg`, `in the red`, ...)
+scoring 0.0000 is **parity with reference**, not a bug. The dead method was
+removed in 2.0.0.
 
----
+What remains is a genuine but small gap: 7 of 21 `idiom/*` cases differ from
+reference, because the port does not implement the forward-looking checks and
+does not apply the `start_i == 2` gate. It is folded into the overall 47%
+figure in section 0 rather than tracked separately.
+
+### A fix was attempted and rejected
+
+A targeted change restoring the forward-looking checks was implemented and
+**abandoned**: without also replicating the `start_i == 2` gate it made idioms
+fire far more often than reference, taking overall divergence from 158 to 166
+cases. Recorded here so it is not retried in isolation — idiom behaviour cannot
+be corrected independently of the surrounding context loop.
 
 ## 3. Dynamic property deprecations (PHP 8.2+) — FIXED in 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHP Sentiment Analyzer
 
-PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool that is used to understand sentiments in a sentence using VADER \(Valence Aware Dictionary and sentiment Reasoner\).
+PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool for PHP, built on the VADER \(Valence Aware Dictionary and sEntiment Reasoner\) sentiment lexicon.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/davmixcool/php-sentiment-analyzer/ci.yml?branch=master&label=CI)](https://github.com/davmixcool/php-sentiment-analyzer/actions/workflows/ci.yml) [![Latest Version](https://img.shields.io/packagist/v/davmixcool/php-sentiment-analyzer?label=latest)](https://packagist.org/packages/davmixcool/php-sentiment-analyzer) [![PHP Version](https://img.shields.io/packagist/php-v/davmixcool/php-sentiment-analyzer/dev-master?label=php)](https://packagist.org/packages/davmixcool/php-sentiment-analyzer) [![Total Downloads](https://img.shields.io/packagist/dt/davmixcool/php-sentiment-analyzer)](https://packagist.org/packages/davmixcool/php-sentiment-analyzer) [![License](https://img.shields.io/packagist/l/davmixcool/php-sentiment-analyzer)](https://github.com/davmixcool/php-sentiment-analyzer/blob/master/LICENCE.txt) [![Stars](https://img.shields.io/github/stars/davmixcool/php-sentiment-analyzer)](https://github.com/davmixcool/php-sentiment-analyzer/stargazers) [![Forks](https://img.shields.io/github/forks/davmixcool/php-sentiment-analyzer)](https://github.com/davmixcool/php-sentiment-analyzer/network/members)
 
@@ -9,6 +9,33 @@ PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool that 
 * Text
 * Emoticon
 * Emoji
+
+## Relationship to VADER
+
+This package uses the **VADER sentiment lexicon verbatim** — the dictionary files
+in `src/Lexicons/` are byte-identical to
+[cjhutto/vaderSentiment](https://github.com/cjhutto/vaderSentiment), and lexicon
+and emoji lookups match the reference implementation exactly.
+
+**The rule engine is an independent port, and it is not score-equivalent with
+reference Python VADER.** Measured across a 336-case corpus, scores differ on
+**47% of cases**. The two largest causes are negation strength and the ordering
+of booster damping:
+
+| Input | This package | Python VADER |
+| --- | --- | --- |
+| `aint good` | -0.1423 | -0.3412 |
+| `very good` | 0.4877 | 0.4927 |
+| `I have never been so happy` | -0.2699 | 0.6948 |
+
+If you need results that match Python VADER exactly, this package will not give
+them to you today. If you need a self-contained, dependency-free, deterministic
+sentiment scorer for PHP, it does that well — and its behaviour is pinned by a
+355-case characterization suite, so it does not drift between releases.
+
+Run `composer conformance` to reproduce the comparison yourself. Full detail,
+including which rules diverge and why, is in
+[KNOWN-DIVERGENCES.md](https://github.com/davmixcool/php-sentiment-analyzer/blob/master/KNOWN-DIVERGENCES.md).
 
 ## Requirements
 
@@ -20,6 +47,7 @@ PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool that 
 
 ## Contents
 
+* [Relationship to VADER](#relationship-to-vader)
 * [Install](#install)
 * [Modern API](#modern-api)
 * [Simple Usage](#simple-usage)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "davmixcool/php-sentiment-analyzer",
     "type": "library",
-    "description": "PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool that is used to understand sentiments in a sentence using VADER (Valence Aware Dictionary and sentiment Reasoner).",
+    "description": "PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool for PHP, built on the VADER (Valence Aware Dictionary and sEntiment Reasoner) sentiment lexicon.",
     "keywords": [
         "NLP",
         "Sentiment Analyzer",
@@ -42,7 +42,8 @@
         "baseline": "php tools/generate-baseline.php",
         "matrix": "./tools/test-matrix.sh",
         "matrix:fresh": "./tools/test-matrix.sh --fresh",
-        "stan": "phpstan analyse --no-progress"
+        "stan": "phpstan analyse --no-progress",
+        "conformance": "./tools/conformance.sh"
     },
     "config": {
         "sort-packages": true

--- a/tools/conformance.sh
+++ b/tools/conformance.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Three-way conformance report: v1 (1.x) vs v2 (master) vs reference Python VADER.
+#
+# The package implements VADER's rule model but is NOT score-equivalent with the
+# reference Python implementation. This measures the gap so it is a tracked
+# number rather than an assertion, per rule section.
+#
+# Read the v1 and v2 columns together: they should be identical, because 2.0.0
+# guarantees byte-identical scores with 1.3.0. The `v1!=v2` column is therefore a
+# regression alarm — any non-zero value means the two lines have drifted.
+#
+# INFORMATIONAL ONLY. Always exits 0, and is deliberately NOT wired into CI:
+# it measures a known, accepted gap, and gating builds on a number we have
+# consciously chosen not to fix yet would block every build.
+#
+# Usage: ./tools/conformance.sh   (or: composer conformance)
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="$PROJECT_DIR/tests/fixtures/baseline.json"
+V1_REF="${CONFORMANCE_V1_REF:-1.x}"
+V2_REF="${CONFORMANCE_V2_REF:-master}"
+
+cd "$PROJECT_DIR"
+
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: the Docker daemon is not reachable."
+    echo "       Start Docker Desktop (open -a Docker), wait for it to report"
+    echo "       running, then re-run this script."
+    exit 0
+fi
+
+if [ ! -f "$FIXTURE" ]; then
+    echo "ERROR: $FIXTURE is missing. Run 'composer baseline' first."
+    exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Corpus texts. Custom-lexicon cases are excluded: the reference cannot
+# replicate a runtime lexicon override, so comparing them is meaningless.
+php -r '
+$b = json_decode(file_get_contents($argv[1]), true);
+$out = [];
+foreach ($b as $k => $v) {
+    if (isset($v["lexicon"]) || trim($v["text"]) === "") { continue; }
+    $out[$k] = $v["text"];
+}
+file_put_contents($argv[2], json_encode($out, JSON_UNESCAPED_UNICODE));
+fprintf(STDERR, "  corpus: %d comparable cases (custom-lexicon cases excluded)\n", count($out));
+' "$FIXTURE" "$WORK/cases.json"
+
+# A minimal PSR-4 shim, so neither branch's composer autoloader is required and
+# both v1 (PHP 5 era) and v2 (typed, 8.1+) can be scored by the same script.
+cat > "$WORK/score.php" <<'PHP'
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE);
+spl_autoload_register(function ($class) {
+    $prefix = 'Sentiment\\';
+    if (strpos($class, $prefix) !== 0) { return; }
+    $path = '/src/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+    if (is_file($argvDir = getenv('SRC_ROOT') . $path)) { require $argvDir; }
+});
+$cases = json_decode(file_get_contents('/w/cases.json'), true);
+$analyzer = new Sentiment\Analyzer();
+$out = [];
+foreach ($cases as $key => $text) {
+    $out[$key] = sprintf('%.4f', $analyzer->getSentiment($text)['compound']);
+}
+file_put_contents(getenv('OUT_FILE'), json_encode($out));
+PHP
+
+score_branch() {
+    local ref="$1" out="$2" stage="$WORK/src-$3"
+    mkdir -p "$stage"
+    git archive "$ref" src | tar -xf - -C "$stage"
+    docker run --rm --user "$(id -u):$(id -g)" \
+        -v "$WORK":/w -v "$stage":/stage -w /w \
+        -e SRC_ROOT=/stage -e "OUT_FILE=/w/$out" \
+        php:8.1-cli php /w/score.php
+}
+
+printf '\n  scoring with v1 (%s)...\n' "$V1_REF"
+score_branch "$V1_REF" "v1.json" "v1"
+
+printf '  scoring with v2 (%s)...\n' "$V2_REF"
+score_branch "$V2_REF" "v2.json" "v2"
+
+printf '  scoring with reference Python VADER...\n'
+cat > "$WORK/ref.py" <<'PY'
+import json
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+from vaderSentiment import __file__ as vf
+a = SentimentIntensityAnalyzer()
+cases = json.load(open('/w/cases.json'))
+json.dump({k: f"{a.polarity_scores(t)['compound']:.4f}" for k, t in cases.items()},
+          open('/w/ref.json', 'w'))
+PY
+docker run --rm --user "$(id -u):$(id -g)" -v "$WORK":/w -w /w \
+    -e HOME=/tmp -e PYTHONDONTWRITEBYTECODE=1 \
+    python:3.11-slim sh -c 'pip install -q --no-cache-dir vaderSentiment >/dev/null 2>&1 && python ref.py'
+
+REF_VERSION="$(docker run --rm python:3.11-slim sh -c \
+    'pip install -q --no-cache-dir vaderSentiment >/dev/null 2>&1 && pip show vaderSentiment 2>/dev/null | awk "/^Version/{print \$2}"' || echo '?')"
+
+php -r '
+$v1  = json_decode(file_get_contents($argv[1]), true);
+$v2  = json_decode(file_get_contents($argv[2]), true);
+$ref = json_decode(file_get_contents($argv[3]), true);
+
+$sec = [];
+foreach ($ref as $k => $r) {
+    $s = explode("/", $k)[0];
+    $sec[$s] ??= ["total" => 0, "v1" => 0, "v2" => 0, "drift" => 0];
+    $sec[$s]["total"]++;
+    if (abs((float) $v1[$k] - (float) $r) > 0.0001) { $sec[$s]["v1"]++; }
+    if (abs((float) $v2[$k] - (float) $r) > 0.0001) { $sec[$s]["v2"]++; }
+    if ($v1[$k] !== $v2[$k]) { $sec[$s]["drift"]++; }
+}
+ksort($sec);
+
+printf("\n  %-18s %8s %8s %8s %7s\n", "section", "v1!=ref", "v2!=ref", "v1!=v2", "total");
+printf("  %s\n", str_repeat("-", 54));
+$t = ["total" => 0, "v1" => 0, "v2" => 0, "drift" => 0];
+foreach ($sec as $name => $c) {
+    foreach ($t as $k => $_) { $t[$k] += $c[$k]; }
+    printf("  %-18s %8d %8d %8d %7d\n", $name, $c["v1"], $c["v2"], $c["drift"], $c["total"]);
+}
+printf("  %s\n", str_repeat("-", 54));
+printf("  %-18s %8d %8d %8d %7d\n", "TOTAL", $t["v1"], $t["v2"], $t["drift"], $t["total"]);
+printf("\n  v2 matches reference on %d of %d cases (%.0f%% divergent)\n",
+    $t["total"] - $t["v2"], $t["total"], 100 * $t["v2"] / $t["total"]);
+
+if ($t["drift"] === 0) {
+    printf("  v1 and v2 agree on every case — the 1.3.0/2.0.0 parity guarantee holds.\n");
+} else {
+    printf("  WARNING: v1 and v2 disagree on %d cases. The lines have drifted.\n", $t["drift"]);
+}
+
+$rows = [];
+foreach ($ref as $k => $r) {
+    $d = abs((float) $v2[$k] - (float) $r);
+    if ($d > 0.0001) { $rows[$k] = $d; }
+}
+arsort($rows);
+printf("\n  largest divergences (v2 vs reference):\n");
+$i = 0;
+foreach ($rows as $k => $d) {
+    if ($i++ >= 8) { break; }
+    printf("    %-26s php=%-9s ref=%-9s delta=%.4f\n", $k, $v2[$k], $ref[$k], $d);
+}
+' "$WORK/v1.json" "$WORK/v2.json" "$WORK/ref.json"
+
+printf "\n  reference: Python vaderSentiment %s\n" "$REF_VERSION"
+printf "  informational only — this does not gate CI\n\n"


### PR DESCRIPTION
Documentation and tooling only. **No source changes, no score movement** — the
355-case baseline is byte-identical to 2.0.0.

## Why

The package described itself as *"…using VADER (Valence Aware Dictionary and
sentiment Reasoner)"*, which implies score equivalence with the reference Python
implementation. Measuring it shows that isn't true:

```
  section             v1!=ref  v2!=ref   v1!=v2   total
  booster                  70       70        0      70
  negation                 59       59        0      59
  idiom                     7        7        0      21
  least_never               5        5        0       8
  never_check               5        5        0      14
  kind_of                   4        4        0       4
  caps · edge · idiom_sentence · punctuation
                            8        8        0      59
  but_clause · emoji · lexicon · readme
                            0        0        0     101
  ------------------------------------------------------
  TOTAL                   158      158        0     336
```

**47% of cases differ from Python vaderSentiment 3.3.2.** Two root causes account
for 129 of the 158:

- **Negation is ~2.5× too weak.** `_never_check()` multiplies by `B_DECR (−0.293)`
  where reference uses `N_SCALAR (−0.74)`. The package systematically
  under-detects negative sentiment.
- **Booster damping is inverted.** Distance damping is applied by array position
  against a `[i−3, i−2, i−1, i]` window, so the *nearest* modifier is damped most
  and the *most distant* not at all.

A third, sharper case: `"I have never been so happy"` scores **−0.2699** here and
**+0.6948** in reference — a sign flip on ordinary English.

**The dictionary half is exact.** All 40 lexicon lookups, 50 emoji cases, 8
but-clause cases and the 3 README examples match reference precisely, and the
lexicon files are byte-identical to upstream. That's why the corrected wording
keeps VADER but scopes the claim to the lexicon.

## Changes

- **Description** (`composer.json` + `README.md`) → *"built on the VADER (Valence
  Aware Dictionary and sEntiment Reasoner) sentiment lexicon"*. The old text also
  miscapitalised *sEntiment*.
- **`composer conformance`** (`tools/conformance.sh`) — three-way comparison of
  the 1.x line, the 2.x line and reference Python VADER, per rule section.
  Informational, always exits 0, and deliberately **not wired into CI**: gating
  builds on a number we've consciously chosen not to fix would block every build.
- **README** gains a "Relationship to VADER" section, placed before Requirements
  so it's read before install.
- **`KNOWN-DIVERGENCES.md`** gains section 0 with the table and root causes.

## The `v1!=v2` column

It reads **0** everywhere, which is the point of including v1. It demonstrates
the 2.0.0 parity guarantee empirically rather than asserting it, and shows the
divergence is **inherited from the original port** — the modernization introduced
none of it. It also acts as a drift alarm: any non-zero value means the two
release lines have silently diverged.

## Section 2 was wrong and is rewritten

`KNOWN-DIVERGENCES.md` previously claimed *"15 of 21 idioms do not fire"*,
measured against the idiom tables in `Config.php`. That framing was incorrect.
Reference VADER gates `_special_idioms_check()` on `start_i == 2`, so idioms only
apply when the sentiment word sits at index ≥ 3 — reference itself scores
`"bad ass"` as −0.7906. And `SENTIMENT_LADEN_IDIOMS` is marked *"future work, not
yet implemented"* upstream and never called, so those 9 idioms being inert is
**parity, not a bug**.

It also records that a targeted idiom fix was **attempted and rejected**: without
replicating the positional gate it made idioms fire more often than reference,
taking divergence from 158 to 166. Documented so it isn't retried in isolation.

## Verification

- `composer test` green (750 tests); `composer stan` clean at level 5
- `git diff 2.0.0 -- tests/fixtures/baseline.json` empty
- `composer matrix` green across PHP 8.1–8.4
- `tools/` remains `export-ignore`d — 0 tooling files in the release tarball
- Every figure in the docs comes from `composer conformance` output, and the
  README table rows were cross-checked against the corpus

## Not in scope

Any scoring change. Full VADER alignment would move roughly half of all scores —
a major-version project for a package with ~184k installs. This work makes that
decision measurable; it doesn't begin it.