### PR TITLE
Align the scoring engine with reference VADER (0 divergence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
   # must stay covered — security backports land there as PRs and are verified
   # against the same characterization baseline as master.
   push:
-    branches: [ master, '1.x' ]
+    branches: [ master, '1.x', '2.x' ]
   pull_request:
-    branches: [ master, '1.x' ]
+    branches: [ master, '1.x', '2.x' ]
 
 jobs:
   tests:
@@ -40,6 +40,13 @@ jobs:
 
       - name: Static analysis
         run: composer stan
+
+      # 3.x is a faithful port of reference VADER; conformance must stay at 0.
+      # Runs once (not per PHP version) — it compares scoring against Python,
+      # which the matrix above already proves is version-independent.
+      - name: VADER conformance
+        if: matrix.php == '8.3'
+        run: composer conformance -- --worktree
 
       # The baseline must be reproducible: regenerating it on a clean checkout
       # must produce no diff. A diff here means scoring is not deterministic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,73 @@ All notable changes to this project are documented here.
 
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [3.0.0] - 2026-08-20
+
+### Scores change — action required
+
+**This release changes sentiment scores.** 157 of 352 shared test cases moved
+(~45%). The package is now a faithful port of reference Python `vaderSentiment`
+3.3.2, verified case-by-case.
+
+**Re-score any stored values and revisit tuned thresholds.** If you need score
+stability, stay on `2.x`, which remains maintained. See `MIGRATION.md`.
+
+**No API changes.** `getSentiment()`, `updateLexicon()`, `analyze()`,
+`analyzeMany()`, `withLexicon()` and `SentimentResult` are unchanged.
+
+### Fixed — scoring engine now matches reference VADER
+
+| Input | 2.x | 3.0 |
+|---|---|---|
+| `aint good` | -0.1423 | **-0.3412** |
+| `I have never been so happy` | -0.2699 | **+0.6948** |
+| `good!!!!` | 0.0000 | **+0.6209** |
+| `he is a kind person` | 0.0000 | **+0.5267** |
+| `kind of good` | 0.1116 | **+0.4404** |
+| `very good` | 0.4877 | **+0.4927** |
+
+- **Negation** used `B_DECR (-0.293)` where VADER specifies `N_SCALAR (-0.74)`,
+  making every negation ~2.5x too weak. The package systematically
+  under-detected negative sentiment.
+- **Booster damping** was applied in reverse distance order, so the nearest
+  modifier was damped most.
+- **`never so` / `never this`** negated instead of intensifying, which could
+  invert the sign of an ordinary sentence.
+- **The tokenizer** dropped single-character tokens (shifting every index, and
+  with it every position-dependent rule) and only stripped punctuation runs
+  present in `PUNC_LIST`, so `"good!!!!"` was never recognised.
+- **Any token equal to `"kind"` or `"of"`** was skipped entirely; reference skips
+  `"kind"` only when followed by `"of"`.
+- **Idiom checks** ran unconditionally instead of only at `start_i == 2`, and the
+  booster n-gram adjustment was applied up to five times per token.
+- **`"no"` handling** was absent.
+- **`_least_check`** lacked its "preceding word not in the lexicon" gate.
+- **Config tables** diverged: `BOOSTER_DICT` was missing 15 entries and carried a
+  non-upstream one (`seemingly`), and `SPECIAL_CASE_IDIOMS` did not match 3.3.2.
+
+### Added
+
+- **`composer conformance` is now a gate.** It scores a 350-case corpus with both
+  this package and Python `vaderSentiment` 3.3.2 and **fails on any divergence**.
+  It runs in CI, so parity cannot silently regress. The reference version is
+  pinned deliberately — the tables differ between releases.
+
+### Changed
+
+- The package description again claims VADER equivalence, because it is now true.
+  2.0.1 had scoped that claim back when measurement showed 47% divergence.
+- The characterization corpus grew from 355 to 369 cases, following the corrected
+  `BOOSTER_DICT`.
+
+### Removed
+
+- Dead scaffolding left by the rewrite: `getWordInContext()`,
+  `adjustBoosterSentiment()`, `modifyValenceBasedOnContext()`,
+  `getTargetWordFromContext()`, `dampendBoosterScalerByPosition()`,
+  `getValenceFromLexicon()`, `IsInLexicon()`. All were private.
+- `SentiText::strip_punctuation()`, `_words_only()` and
+  `array_count_values_of()`, which existed only to support the old tokenizer.
+
 ## [2.0.1] - 2026-08-20
 
 ### Scores are unchanged

--- a/KNOWN-DIVERGENCES.md
+++ b/KNOWN-DIVERGENCES.md
@@ -18,95 +18,47 @@ This file is the worklist for the post-2.0 scoring-fix release.
 
 ---
 
-## 0. Conformance with reference VADER — 47% of cases differ
+## 0. Conformance with reference VADER — RESOLVED in 3.0.0
 
-The package implements VADER's rule model but is **not score-equivalent** with
-the reference Python implementation. Measured with `composer conformance`
-against Python `vaderSentiment` 3.3.2 over 336 corpus cases:
+**The package now matches reference Python `vaderSentiment` 3.3.2 exactly**, on
+all 350 comparable corpus cases. Verified by `composer conformance`, which fails
+the build on any divergence and runs in CI.
 
-| Section | v1 differs | v2 differs | v1 vs v2 | total |
-|---|---|---|---|---|
-| booster | 70 | 70 | 0 | 70 |
-| negation | 59 | 59 | 0 | 59 |
-| idiom | 7 | 7 | 0 | 21 |
-| least_never | 5 | 5 | 0 | 8 |
-| never_check | 5 | 5 | 0 | 14 |
-| kind_of | 4 | 4 | 0 | 4 |
-| caps | 2 | 2 | 0 | 8 |
-| edge | 2 | 2 | 0 | 18 |
-| idiom_sentence | 2 | 2 | 0 | 21 |
-| punctuation | 2 | 2 | 0 | 12 |
-| but_clause | 0 | 0 | 0 | 8 |
-| emoji | 0 | 0 | 0 | 25 |
-| emoji_sentence | 0 | 0 | 0 | 25 |
-| lexicon | 0 | 0 | 0 | 40 |
-| readme | 0 | 0 | 0 | 3 |
-| **TOTAL** | **158** | **158** | **0** | **336** |
+Before 3.0.0 the port diverged on **158 of 336 cases (47%)**. The causes, all
+fixed:
 
-Two observations before the causes.
+| Cause | Effect before 3.0.0 |
+|---|---|
+| Negation used `B_DECR (-0.293)` instead of `N_SCALAR (-0.74)` | `"aint good"` scored -0.1423, not -0.3412 — negation ~2.5x too weak |
+| Booster damping applied in reverse distance order | `"very good"` scored 0.4877, not 0.4927 |
+| `never so`/`never this` negated instead of intensifying | `"I have never been so happy"` scored **-0.2699**, not **+0.6948** |
+| Tokenizer dropped single-character tokens and only stripped punctuation runs listed in `PUNC_LIST` | `"good!!!!"` scored **0.0000**; token indices were shifted, breaking every positional rule |
+| Any token equal to `"kind"` or `"of"` was skipped | `"he is a kind person"` scored **0.0000**, not 0.5267 |
+| Idiom checks ran unconditionally, and the booster n-gram was applied up to five times | `"kind of good"` scored 0.1116, not 0.4404 |
+| `BOOSTER_DICT` was missing 15 entries and carried a non-upstream one (`seemingly`); `SPECIAL_CASE_IDIOMS` diverged from 3.3.2 | assorted |
 
-**The dictionary half is exact.** All 40 lexicon lookups, 50 emoji cases, 8
-but-clause cases and the 3 README examples match reference precisely. The
-lexicon files are byte-identical to upstream.
+### Why the reference version is pinned
 
-**v1 and v2 agree on every case.** The divergence is inherited from the original
-port; the 2.0.0 modernization introduced none of it. That column is also a
-regression alarm — a non-zero value means the two release lines have drifted.
+`composer conformance` pins `vaderSentiment==3.3.2` deliberately. The tables
+differ between releases — 3.3.2 has `"beating heart" => 3.5` and no
+`"broken heart"`, while the GitHub master source has `3.1` and `-2.9`. Parity is
+only meaningful against a fixed target. Override with `VADER_VERSION=` if you
+need to compare against another release.
 
-### Cause 1 — negation is ~2.5x too weak
+### Deliberate quirks
 
-`_never_check()` multiplies by `B_DECR (-0.293)` where reference uses
-`N_SCALAR (-0.74)`.
+Being a faithful port means reproducing reference behaviour that looks wrong:
 
-```
-"aint good"    this package: -0.1423     reference: -0.3412
-```
+- **`SENTIMENT_LADEN_IDIOMS` is unimplemented.** Upstream marks it *"future work,
+  not yet implemented"* and never calls it, so `"under the weather"` and
+  `"break a leg"` score 0.0000 in both implementations.
+- **Idioms only apply at token index >= 3.** Reference gates the idiom check on
+  `start_i == 2`, so `"bad ass"` alone scores -0.7906 while
+  `"it was a bad ass"` scores +0.6124 — in reference too.
+- **An operator-precedence quirk** in `_negation_check` at `start_i == 2` makes
+  the `so`/`this` intensifier fire whether or not `never` is present. Reproduced.
 
-Because every negated phrase is scaled by roughly a third of the intended
-amount, the package **systematically under-detects negative sentiment**. This is
-the single highest-impact divergence: it affects all 59 negation cases.
-
-### Cause 2 — booster damping is inverted
-
-`getWordInContext()` returns `[i-3, i-2, i-1, i]`, but the distance damping
-(none / x0.95 / x0.9) is applied by array position. The result is that the
-*nearest* modifier is damped most and the *most distant* not at all — the
-opposite of the intent.
-
-```
-"very good"    this package: 0.4877      reference: 0.4927
-```
-
-### Cause 3 — "never so/this" flips sign
-
-Reference treats `never so` / `never this` as an intensifier (x1.25 / x1.5)
-without negating. The port negates as well, which can invert the sign of an
-ordinary sentence:
-
-```
-"I have never been so happy"    this package: -0.2699    reference: +0.6948
-```
-
-### Status — planned for 3.0.0
-
-**These will be fixed.** Alignment with reference VADER is planned for the next
-major release.
-
-It has to be a major release: correcting negation and booster damping moves
-roughly half of all scores. It will not arrive in a patch or minor version. The
-release will carry a full before/after breakdown and an explicit re-score
-warning, as `1.3.0` did for a smaller change.
-
-They are also deliberately **not** being fixed piecemeal. These rules interact —
-an isolated idiom fix was attempted and made overall divergence worse (see
-section 2) — so alignment is a single coordinated change verified against the
-characterization corpus, not a series of patches.
-
-Progress is measurable: `composer conformance` reports divergence per rule
-section, so this is a number going to zero rather than a judgement call.
-
-If you would rather not move, the current behaviour remains available on the
-existing release lines, which stay maintained.
+These are noted so they are not "fixed" into a divergence.
 
 ## 1. `_never_check` zeroed sentiment after "so" or "this" — FIXED in 1.3.0
 
@@ -137,44 +89,36 @@ still score -0.2385 and -0.2108. No other pinned case moved.
 **This is the one deliberate scoring change in the 1.x line.** Everything below
 remains pinned as-is.
 
-## 2. Idioms rarely fire — mostly matching reference
+## 2. Idioms rarely fire — matching reference
+
+Idioms seldom affect a score, and that is correct. Reference VADER gates
+`_special_idioms_check()` on `start_i == 2`, so an idiom only applies when the
+sentiment word sits at index >= 3 with a non-lexicon word three positions back:
+
+```
+"bad ass"              -0.7906   (idiom value +1.5 not applied)
+"the shit"             -0.5574   (idiom value +3 not applied)
+"it was a bad ass"     +0.6124   (idiom applied)
+```
+
+Both implementations agree on all of these as of 3.0.0.
 
 An earlier version of this file claimed "15 of 21 idioms do not fire" and
-measured each idiom against its value in `src/Config/Config.php`. **That framing
-was wrong**, and it is corrected here.
+measured each against its value in `Config.php`. That framing was wrong: the
+tables were never the contract, and most of those cases were parity with
+reference rather than defects.
 
-The idiom tables were never the contract. Reference VADER gates
-`_special_idioms_check()` on `start_i == 2`, so an idiom is only consulted when
-the sentiment word sits at index >= 3 with a non-lexicon word three positions
-back. Short phrases therefore never trigger it — in reference VADER itself:
+**`SENTIMENT_LADEN_IDIOMS` remains unimplemented**, matching upstream, which
+marks it *"future work, not yet implemented"* and never calls it. The constant is
+retained so the data is not lost, but nothing reads it.
 
-```
-"bad ass"              reference: -0.7906   (idiom value +1.5 not applied)
-"the shit"             reference: -0.5574   (idiom value +3 not applied)
-"it was a bad ass"     reference: +0.6124   (idiom applied)
-```
+### A piecemeal fix was attempted and rejected
 
-So "the idiom didn't fire" is usually correct behaviour, not a defect.
-
-**`SENTIMENT_LADEN_IDIOMS` is unimplemented on purpose.** Upstream marks it
-*"future work, not yet implemented"*, never calls its own
-`_sentiment_laden_idioms_check()`, and leaves a debug `print()` inside it. The
-9 laden-only idioms (`under the weather`, `break a leg`, `in the red`, ...)
-scoring 0.0000 is **parity with reference**, not a bug. The dead method was
-removed in 2.0.0.
-
-What remains is a genuine but small gap: 7 of 21 `idiom/*` cases differ from
-reference, because the port does not implement the forward-looking checks and
-does not apply the `start_i == 2` gate. It is folded into the overall 47%
-figure in section 0 rather than tracked separately.
-
-### A fix was attempted and rejected
-
-A targeted change restoring the forward-looking checks was implemented and
-**abandoned**: without also replicating the `start_i == 2` gate it made idioms
+Before 3.0.0, a targeted change restoring only the forward-looking idiom checks
+was implemented and **abandoned**: without the `start_i == 2` gate it made idioms
 fire far more often than reference, taking overall divergence from 158 to 166
-cases. Recorded here so it is not retried in isolation — idiom behaviour cannot
-be corrected independently of the surrounding context loop.
+cases. That is why 3.0.0 rewrote the scoring loop as a whole rather than patching
+rules individually — they interact.
 
 ## 3. Dynamic property deprecations (PHP 8.2+) — FIXED in 2.0.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,80 @@
-# Migrating from 1.x to 2.0
+# Migration guide
+
+Start with the section for the upgrade you are making. The 2.x to 3.0 move
+changes scores; the 1.x to 2.0 move does not.
+
+---
+
+## Migrating from 2.x to 3.0
+
+**Your sentiment scores change.** 3.0.0 makes the package a faithful port of
+reference Python `vaderSentiment` 3.3.2 — 157 of 352 shared test cases moved,
+roughly 45%.
+
+**There are no API changes.** `getSentiment()`, `updateLexicon()`, `analyze()`,
+`analyzeMany()`, `withLexicon()` and `SentimentResult` are all unchanged. Only
+the numbers they return are different, and they are different because they were
+wrong.
+
+### What you need to do
+
+**Re-score any stored sentiment values, and revisit any tuned thresholds.** If
+you have a rule like "flag anything below -0.3", it will now behave differently —
+in most cases it will catch more genuinely negative text than before.
+
+If you cannot re-score right now, stay on 2.x:
+
+```bash
+composer require davmixcool/php-sentiment-analyzer:^2.0
+```
+
+`2.x` remains maintained with security fixes, and its scores are frozen.
+
+### What changed and why
+
+| Input | 2.x | 3.0 |
+|---|---|---|
+| `aint good` | -0.1423 | **-0.3412** |
+| `not good` | -0.1423 | **-0.3412** |
+| `I have never been so happy` | -0.2699 | **+0.6948** |
+| `never so good` | -0.2385 | **+0.5777** |
+| `without doubt good` | -0.0302 | **+0.6136** |
+| `good!!!!` | 0.0000 | **+0.6209** |
+| `good????` | 0.0000 | **+0.5940** |
+| `he is a kind person` | 0.0000 | **+0.5267** |
+| `kind of good` | 0.1116 | **+0.4404** |
+| `very good` | 0.4877 | **+0.4927** |
+| `the shit` | +0.6124 | **-0.5574** |
+
+The most consequential fix is **negation**. 2.x scaled negated phrases by
+`-0.293` where VADER specifies `-0.74`, so every negation was roughly 2.5x too
+weak and the package systematically under-detected negative sentiment. If you
+were compensating for that with a lower threshold, you can stop.
+
+Three cases worth understanding because they look like regressions:
+
+- **`"the shit"` and `"the bomb"` now score negative.** VADER only applies idiom
+  values when the sentiment word sits at index >= 3, so these short phrases score
+  from their constituent words. Reference does the same.
+- **`"never so good"` flipped from negative to positive.** VADER treats
+  `never so` / `never this` as an intensifier, not a negation.
+- **`"good!!!!"` was returning 0.0000.** The old tokenizer only stripped
+  punctuation runs it had a literal entry for, so four exclamation marks left the
+  word unrecognised.
+
+### Verifying it yourself
+
+```bash
+composer conformance
+```
+
+Scores a 350-case corpus with both this package and Python `vaderSentiment`
+3.3.2, and fails if any case differs. It runs in CI on every push, so parity
+cannot silently regress.
+
+---
+
+## Migrating from 1.x to 2.0
 
 **Your sentiment scores do not change.** 2.0 produces byte-identical `neg`,
 `neu`, `pos` and `compound` values to `1.3.0` across the full 355-case
@@ -10,7 +86,7 @@ belongs to `1.3.0`, not to 2.0. See the "Coming from 1.2.2 or earlier" section.
 
 ---
 
-## 1. PHP 8.1 is required
+### 1. PHP 8.1 is required
 
 ```json
 "require": { "php": "^8.1" }
@@ -23,7 +99,7 @@ older runtime, so no amount of API compatibility helps there.
 security fixes, and carries the same test suite. `composer require
 davmixcool/php-sentiment-analyzer:^1.3` pins you to it.
 
-## 2. What has NOT changed
+### 2. What has NOT changed
 
 These are frozen and enforced by `tests/ApiContractTest.php`:
 
@@ -40,7 +116,7 @@ $analyzer->updateLexicon(['rubbish' => -1.5]); // same lowercasing, same coercio
 - The constructor keeps resolving lexicon paths relative to the package's `src/`
   directory.
 
-## 2b. The new API (optional)
+### 2b. The new API (optional)
 
 Nothing below is required. `getSentiment()` keeps working exactly as before; the
 new API is opt-in and layered over it, returning the same numbers.
@@ -84,7 +160,7 @@ only in some positions. A clear error beats a feature that works sometimes.
 
 `explain()` is not in 2.0 — it is scheduled for 2.2.
 
-## 3. Accepted breaks
+### 3. Accepted breaks
 
 ### 3.1 Internal methods are now private
 
@@ -128,7 +204,7 @@ v1 called `die()`, terminating the host process — behaviour a library should
 never impose on the application embedding it. If you passed a custom lexicon
 path and relied on the process dying, you now need a `catch`.
 
-## 4. Coming from 1.2.2 or earlier
+### 4. Coming from 1.2.2 or earlier
 
 `1.3.0` fixed a defect in `_never_check()` that zeroed the sentiment of any word
 within two tokens of "so" or "this":
@@ -142,7 +218,7 @@ within two tokens of "so" or "this":
 **Re-score any stored text** containing those words near sentiment terms. This
 change is attributable to `1.3.0`; 2.0 inherits it unchanged.
 
-## 5. What has not been fixed
+### 5. What has not been fixed
 
 2.0 is a modernization, not a scoring release. Known divergences from reference
 VADER — most notably **15 of 21 idioms that never fire** — are reproduced

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHP Sentiment Analyzer
 
-PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool for PHP, built on the VADER \(Valence Aware Dictionary and sEntiment Reasoner\) sentiment lexicon.
+PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool for PHP using VADER \(Valence Aware Dictionary and sEntiment Reasoner\), matching the reference Python implementation exactly.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/davmixcool/php-sentiment-analyzer/ci.yml?branch=master&label=CI)](https://github.com/davmixcool/php-sentiment-analyzer/actions/workflows/ci.yml) [![Latest Version](https://img.shields.io/packagist/v/davmixcool/php-sentiment-analyzer?label=latest)](https://packagist.org/packages/davmixcool/php-sentiment-analyzer) [![PHP Version](https://img.shields.io/packagist/php-v/davmixcool/php-sentiment-analyzer/dev-master?label=php)](https://packagist.org/packages/davmixcool/php-sentiment-analyzer) [![Total Downloads](https://img.shields.io/packagist/dt/davmixcool/php-sentiment-analyzer)](https://packagist.org/packages/davmixcool/php-sentiment-analyzer) [![License](https://img.shields.io/packagist/l/davmixcool/php-sentiment-analyzer)](https://github.com/davmixcool/php-sentiment-analyzer/blob/master/LICENCE.txt) [![Stars](https://img.shields.io/github/stars/davmixcool/php-sentiment-analyzer)](https://github.com/davmixcool/php-sentiment-analyzer/stargazers) [![Forks](https://img.shields.io/github/forks/davmixcool/php-sentiment-analyzer)](https://github.com/davmixcool/php-sentiment-analyzer/network/members)
 
@@ -12,30 +12,24 @@ PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool for P
 
 ## Relationship to VADER
 
-This package uses the **VADER sentiment lexicon verbatim** — the dictionary files
-in `src/Lexicons/` are byte-identical to
-[cjhutto/vaderSentiment](https://github.com/cjhutto/vaderSentiment), and lexicon
-and emoji lookups match the reference implementation exactly.
+**This package matches reference Python
+[vaderSentiment](https://github.com/cjhutto/vaderSentiment) 3.3.2 exactly.**
 
-**The rule engine is an independent port, and it is not score-equivalent with
-reference Python VADER.** Measured across a 336-case corpus, scores differ on
-**47% of cases**. The two largest causes are negation strength and the ordering
-of booster damping:
+The lexicon files are byte-identical to upstream, and the rule engine is a
+faithful port — including reference VADER's own quirks, so that scores agree
+rather than merely being close. Conformance is verified, not asserted:
 
-| Input | This package | Python VADER |
-| --- | --- | --- |
-| `aint good` | -0.1423 | -0.3412 |
-| `very good` | 0.4877 | 0.4927 |
-| `I have never been so happy` | -0.2699 | 0.6948 |
+```bash
+composer conformance
+```
 
-If you need results that match Python VADER exactly, this package will not give
-them to you today. If you need a self-contained, dependency-free, deterministic
-sentiment scorer for PHP, it does that well — and its behaviour is pinned by a
-355-case characterization suite, so it does not drift between releases.
+That scores a 350-case corpus with both implementations and fails if a single
+case differs. It runs in CI on every push.
 
-Run `composer conformance` to reproduce the comparison yourself. Full detail,
-including which rules diverge and why, is in
-[KNOWN-DIVERGENCES.md](https://github.com/davmixcool/php-sentiment-analyzer/blob/master/KNOWN-DIVERGENCES.md).
+Before 3.0.0 this was not true — the port diverged from reference on 47% of
+cases, most importantly by applying negation at roughly a third of its intended
+strength. See [MIGRATION.md](https://github.com/davmixcool/php-sentiment-analyzer/blob/master/MIGRATION.md)
+if you are upgrading from 1.x or 2.x, because **your scores will change**.
 
 ## Requirements
 
@@ -82,11 +76,11 @@ use Sentiment\Analyzer;
 $analyzer = new Analyzer();
 $result   = $analyzer->analyze('This update is really good!');
 
-$result->compound();    // 0.5355
+$result->compound();    // 0.5400
 $result->label();       // 'positive'
 $result->isPositive();  // true
-$result->positive();    // 0.463
-$result->toArray();     // ['positive' => 0.463, 'negative' => 0.0, 'neutral' => 0.537, 'compound' => 0.5355, 'label' => 'positive']
+$result->positive();    // 0.466
+$result->toArray();     // ['positive' => 0.466, 'negative' => 0.0, 'neutral' => 0.534, 'compound' => 0.5400, 'label' => 'positive']
 ```
 
 Labels follow the VADER convention and are exposed as constants, so you can
@@ -145,7 +139,7 @@ print_r($output_text_with_emoji);
 ```text
 David is smart, handsome, and funny. ---------------- ['neg'=> 0.0, 'neu'=> 0.254, 'pos'=> 0.746, 'compound'=> 0.8316]
 
-😁 ------------------- ['neg' => 0, 'neu' => 0.5, 'pos' => 0.5, 'compound' => 0.4588]
+😁 ------------------- ['neg' => 0, 'neu' => 0.571, 'pos' => 0.429, 'compound' => 0.4588]
 
 Aproko doctor made me 🤣 ------------- ['neg' => 0, 'neu' => 0.714, 'pos' =>  0.286, 'compound' => 0.4939]
 ```
@@ -199,11 +193,11 @@ This cake looks amazing  ------------- {"neg":0,"neu":0.441,"pos":0.559,"compoun
 
 His skills are mediocre  ------------- {"neg":0.4,"neu":0.6,"pos":0,"compound":-0.25}
 
-He is very talented  ------------- {"neg":0,"neu":0.457,"pos":0.543,"compound":0.552}
+He is very talented  ------------- {"neg":0,"neu":0.455,"pos":0.545,"compound":0.5563}
 
-She is seemingly very agressive  ------------- {"neg":0.338,"neu":0.662,"pos":0,"compound":-0.2598}
+She is seemingly very agressive  ------------- {"neg":0.31,"neu":0.69,"pos":0,"compound":-0.2006}
 
-Marie was enthusiastic about the upcoming trip. Her brother was also passionate about her leaving - he would finally have the house for himself.  ------------- {"neg":0,"neu":0.761,"pos":0.239,"compound":0.765}
+Marie was enthusiastic about the upcoming trip. Her brother was also passionate about her leaving - he would finally have the house for himself.  ------------- {"neg":0,"neu":0.769,"pos":0.231,"compound":0.765}
 
 String: To be or not to be?  ------------- {"neg":0,"neu":1,"pos":0,"compound":0}
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "davmixcool/php-sentiment-analyzer",
     "type": "library",
-    "description": "PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool for PHP, built on the VADER (Valence Aware Dictionary and sEntiment Reasoner) sentiment lexicon.",
+    "description": "PHP Sentiment Analyzer is a lexicon and rule-based sentiment analysis tool for PHP using VADER (Valence Aware Dictionary and sEntiment Reasoner), matching the reference Python implementation exactly.",
     "keywords": [
         "NLP",
         "Sentiment Analyzer",

--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -109,57 +109,9 @@ class Analyzer
         return Config::BOOSTER_DICT[strtolower($word)];
     }
 
-    private function IsInLexicon(string $word): bool
-    {
-        $lowercase = strtolower($word);
-
-        return array_key_exists($lowercase, $this->lexicon);
-    }
-
     private function IsUpperCaseWord(string $word): bool
     {
         return ctype_upper($word);
-    }
-
-    private function getValenceFromLexicon($word)
-    {
-        return $this->lexicon[strtolower($word)];
-    }
-
-    private function getTargetWordFromContext(array $wordInContext): string
-    {
-        return $wordInContext[count($wordInContext)-1];
-    }
-
-    /*
-        Gets the precedding two words to check for emphasis
-    */
-    private function getWordInContext(array $wordList, int $currentWordPosition): array
-    {
-        $precedingWordList =[];
-
-        //push the actual word on to the context list
-        array_unshift($precedingWordList, $wordList[$currentWordPosition]);
-        //If the word position is greater than 2 then we know we are not going to overflow
-        if (($currentWordPosition-1)>=0) {
-            array_unshift($precedingWordList, $wordList[$currentWordPosition-1]);
-        } else {
-            array_unshift($precedingWordList, "");
-        }
-
-        if (($currentWordPosition-2)>=0) {
-            array_unshift($precedingWordList, $wordList[$currentWordPosition-2]);
-        } else {
-            array_unshift($precedingWordList, "");
-        }
-
-        if (($currentWordPosition-3)>=0) {
-            array_unshift($precedingWordList, $wordList[$currentWordPosition-3]);
-        } else {
-            array_unshift($precedingWordList, "");
-        }
-
-        return $precedingWordList;
     }
 
     /*
@@ -194,28 +146,25 @@ class Analyzer
         $sentiments = [];
         $words_and_emoticons = $this->current_sentitext->getWordsAndEmoticons();
 
-        for ($i=0; $i<=count($words_and_emoticons)-1; $i++) {
-            $valence = 0.0;
-            $wordBeingTested = $words_and_emoticons[$i];
+        for ($i = 0; $i <= count($words_and_emoticons) - 1; $i++) {
+            $itemLower = strtolower($words_and_emoticons[$i]);
 
-            //If this is a booster word add a 0 valances then go to next word as it does not express sentiment directly
-           /* if ($this->IsBoosterWord($wordBeingTested)){
-                echo "\t\tThe word is a booster word: setting sentiment to 0.0\n";
-            }*/
- //var_dump($i);
-            //If the word is not in the Lexicon then it does not express sentiment. So just ignore it.
-            if ($this->IsInLexicon($wordBeingTested)) {
-
-                //Special case because kind is in the lexicon so the modifier kind of needs to be skipped
-                if ("kind" !=$words_and_emoticons[$i] && "of" != $words_and_emoticons[$i]) {
-                    $valence = $this->getValenceFromLexicon($wordBeingTested);
-
-                    $wordInContext = $this->getWordInContext($words_and_emoticons, $i);
-                    //If we are here then we have a word that enhance booster words
-                    $valence = $this->adjustBoosterSentiment($wordInContext, $valence);
-                }
+            // Lexicon words that act as modifiers or negations score 0 themselves.
+            if (array_key_exists($itemLower, Config::BOOSTER_DICT)) {
+                $sentiments[] = 0.0;
+                continue;
             }
-            array_push($sentiments, $valence);
+
+            // "kind" only when followed by "of" — the previous implementation
+            // skipped every "kind" and every "of", zeroing "he is a kind person".
+            if ($i < count($words_and_emoticons) - 1
+                && $itemLower === "kind"
+                && strtolower($words_and_emoticons[$i + 1]) === "of") {
+                $sentiments[] = 0.0;
+                continue;
+            }
+
+            $sentiments[] = $this->sentimentValence($words_and_emoticons, $i);
         }
         //Once we have a sentiment for each word adjust the sentimest if but is present
         $sentiments = $this->_but_check($words_and_emoticons, $sentiments);
@@ -300,6 +249,73 @@ class Analyzer
         $this->current_sentitext = null;
     }
 
+    /**
+     * Score one token in context. Mirrors sentiment_valence() in reference VADER.
+     *
+     * The previous implementation walked a precomputed [i-3, i-2, i-1, i] window
+     * by array position, which inverted the distance damping, omitted the
+     * "preceding word not in the lexicon" gate, and applied negation and idiom
+     * checks once outside the loop instead of per step. This follows the
+     * reference structure directly.
+     *
+     * @param array<int, string> $words
+     */
+    private function sentimentValence(array $words, int $i): float
+    {
+        $item = $words[$i];
+        $itemLower = strtolower($item);
+
+        if (!array_key_exists($itemLower, $this->lexicon)) {
+            return 0.0;
+        }
+
+        $valence = (float) $this->lexicon[$itemLower];
+
+        // "no" as a negator for an adjacent lexicon item, vs "no" standing alone.
+        if ($itemLower === "no"
+            && $i !== count($words) - 1
+            && array_key_exists(strtolower($words[$i + 1]), $this->lexicon)) {
+            $valence = 0.0;
+        }
+
+        if (($i > 0 && strtolower($words[$i - 1]) === "no")
+            || ($i > 1 && strtolower($words[$i - 2]) === "no")
+            || ($i > 2 && strtolower($words[$i - 3]) === "no"
+                && in_array(strtolower($words[$i - 1]), ["or", "nor"], true))) {
+            $valence = (float) $this->lexicon[$itemLower] * Config::N_SCALAR;
+        }
+
+        $valence = $this->applyValenceCapsBoost($item, $valence);
+
+        for ($startI = 0; $startI < 3; $startI++) {
+            $precedingIndex = $i - ($startI + 1);
+
+            if ($i <= $startI
+                || array_key_exists(strtolower($words[$precedingIndex]), $this->lexicon)) {
+                continue;
+            }
+
+            $scalar = $this->boosterScaleAdjustment($words[$precedingIndex], $valence);
+
+            if ($startI === 1 && $scalar !== 0.0) {
+                $scalar *= 0.95;
+            }
+
+            if ($startI === 2 && $scalar !== 0.0) {
+                $scalar *= 0.9;
+            }
+
+            $valence += $scalar;
+            $valence = $this->_negation_check($valence, $words, $startI, $i);
+
+            if ($startI === 2) {
+                $valence = $this->_idioms_check($valence, $words, $i);
+            }
+        }
+
+        return $this->_least_check($valence, $words, $i);
+    }
+
     /** @return array<int, string> */
     private function str_split_unicode(string $str): array
     {
@@ -345,73 +361,23 @@ class Analyzer
     // dampen the scalar modifier of preceding words and emoticons
     // (excluding the ones that immediately preceed the item) based
     // on their distance from the current item.
-    private function dampendBoosterScalerByPosition($booster, $position)
+    /**
+     * Mirrors _least_check() in reference VADER, including the
+     * "preceding word not in the lexicon" gate that was missing here.
+     *
+     * @param array<int, string> $words
+     */
+    private function _least_check(float $valence, array $words, int $i): float
     {
-        if (0===$booster) {
-            return $booster;
-        }
+        $prev = $i > 0 ? strtolower($words[$i - 1]) : '';
+        $prevInLexicon = $i > 0 && array_key_exists($prev, $this->lexicon);
 
-        if (1==$position) {
-            return $booster*0.95;
-        }
-
-        if (2==$position) {
-            return $booster*0.9;
-        }
-
-        return $booster;
-    }
-
-    private function adjustBoosterSentiment($wordInContext, $valence)
-    {
-        //The target word is always the last word
-        $targetWord = $this->getTargetWordFromContext($wordInContext);
-
-        //check if sentiment laden word is in ALL CAPS (while others aren't) and apply booster
-        $valence = $this->applyValenceCapsBoost($targetWord, $valence);
-
-        $valence = $this->modifyValenceBasedOnContext($wordInContext, $valence);
-
-        return $valence;
-    }
-
-    private function modifyValenceBasedOnContext($wordInContext, $valence)
-    {
-        $wordToTest = $this->getTargetWordFromContext($wordInContext);
-            //if($this->IsInLexicon($wordToTest)){
-            //  continue;
-            //}
-        for ($i=0; $i<count($wordInContext)-1; $i++) {
-            $scalarValue = $this->boosterScaleAdjustment($wordInContext[$i], $valence);
-            $scalarValue = $this->dampendBoosterScalerByPosition($scalarValue, $i);
-            $valence = $valence+$scalarValue;
-        }
-
-        $valence = $this->_never_check($wordInContext, $valence);
-
-        $valence = $this->_idioms_check($wordInContext, $valence);
-
-        // future work: consider other sentiment-laden idioms
-        // other_idioms =
-        // {"back handed": -2, "blow smoke": -2, "blowing smoke": -2,
-        //  "upper hand": 1, "break a leg": 2,
-        //  "cooking with gas": 2, "in the black": 2, "in the red": -2,
-        //  "on the ball": 2,"under the weather": -2}
-
-        $valence = $this->_least_check($wordInContext, $valence);
-
-        return $valence;
-    }
-
-    private function _least_check($wordInContext, $valence)
-    {
-        // check for negation case using "least"
-        //if the previous word is least"
-        if (strtolower($wordInContext[2]) == "least") {
-            //but not "at least {word}" "very least {word}"
-            if (strtolower($wordInContext[1]) != "at" && strtolower($wordInContext[1]) != "very") {
-                $valence = $valence*Config::N_SCALAR;
+        if ($i > 1 && !$prevInLexicon && $prev === "least") {
+            if (strtolower($words[$i - 2]) !== "at" && strtolower($words[$i - 2]) !== "very") {
+                $valence *= Config::N_SCALAR;
             }
+        } elseif ($i > 0 && !$prevInLexicon && $prev === "least") {
+            $valence *= Config::N_SCALAR;
         }
 
         return $valence;
@@ -437,84 +403,106 @@ class Analyzer
         return $sentiments;
     }
 
-    private function _idioms_check($wordInContext, $valence)
+    /**
+     * Mirrors _special_idioms_check() in reference VADER.
+     *
+     * Only ever called at startI === 2, matching the reference — which is why
+     * short phrases such as "bad ass" do not pick up their idiom value in either
+     * implementation.
+     *
+     * @param array<int, string> $words
+     */
+    private function _idioms_check(float $valence, array $words, int $i): float
     {
-        $onezero = sprintf("%s %s", $wordInContext[2], $wordInContext[3]);
+        $lower = array_map('strtolower', $words);
 
-        $twoonezero = sprintf("%s %s %s", $wordInContext[1], $wordInContext[2], $wordInContext[3]);
+        $onezero     = sprintf("%s %s", $lower[$i - 1], $lower[$i]);
+        $twoonezero  = sprintf("%s %s %s", $lower[$i - 2], $lower[$i - 1], $lower[$i]);
+        $twoone      = sprintf("%s %s", $lower[$i - 2], $lower[$i - 1]);
+        $threetwoone = sprintf("%s %s %s", $lower[$i - 3], $lower[$i - 2], $lower[$i - 1]);
+        $threetwo    = sprintf("%s %s", $lower[$i - 3], $lower[$i - 2]);
 
-        $twoone = sprintf("%s %s", $wordInContext[1], $wordInContext[2]);
-
-        $threetwoone = sprintf("%s %s %s", $wordInContext[0], $wordInContext[1], $wordInContext[2]);
-
-        $threetwo = sprintf("%s %s", $wordInContext[0], $wordInContext[1]);
-
-        $zeroone = sprintf("%s %s", $wordInContext[3], $wordInContext[2]);
-
-        $zeroonetwo = sprintf("%s %s %s", $wordInContext[3], $wordInContext[2], $wordInContext[1]);
-
-        $sequences = [$onezero, $twoonezero, $twoone, $threetwoone, $threetwo];
-
-        foreach ($sequences as $seq) {
-            $key = strtolower($seq);
-            if (array_key_exists($key, Config::SPECIAL_CASE_IDIOMS)) {
-                $valence = Config::SPECIAL_CASE_IDIOMS[$key];
+        foreach ([$onezero, $twoonezero, $twoone, $threetwoone, $threetwo] as $seq) {
+            if (array_key_exists($seq, Config::SPECIAL_CASE_IDIOMS)) {
+                $valence = (float) Config::SPECIAL_CASE_IDIOMS[$seq];
                 break;
             }
+        }
 
-/*
-            Positive idioms check.  Not implementing it yet
-            if(count($words_and_emoticons)-1 > $i){
-                $zeroone = sprintf("%s %s",$words_and_emoticons[$i], $words_and_emoticons[$i+1]);
-               if (in_array($zeroone, Config::SPECIAL_CASE_IDIOMS)){
-                    $valence = Config::SPECIAL_CASE_IDIOMS[$zeroone];
-                }
-            }
-            if(count($words_and_emoticons)-1 > $i+1){
-                $zeroonetwo = sprintf("%s %s %s",$words_and_emoticons[$i], $words_and_emoticons[$i+1], $words_and_emoticons[$i+2]);
-                if (in_array($zeroonetwo, Config::SPECIAL_CASE_IDIOMS)){
-                    $valence = Config::SPECIAL_CASE_IDIOMS[$zeroonetwo];
-                }
-            }
-*/
+        $lastIndex = count($lower) - 1;
 
-            // check for booster/dampener bi-grams such as 'sort of' or 'kind of'
-            if ($this->IsBoosterWord($threetwo) || $this->IsBoosterWord($twoone)) {
-                $valence = $valence+Config::B_DECR;
+        if ($lastIndex > $i) {
+            $zeroone = sprintf("%s %s", $lower[$i], $lower[$i + 1]);
+            if (array_key_exists($zeroone, Config::SPECIAL_CASE_IDIOMS)) {
+                $valence = (float) Config::SPECIAL_CASE_IDIOMS[$zeroone];
+            }
+        }
+
+        if ($lastIndex > $i + 1) {
+            $zeroonetwo = sprintf("%s %s %s", $lower[$i], $lower[$i + 1], $lower[$i + 2]);
+            if (array_key_exists($zeroonetwo, Config::SPECIAL_CASE_IDIOMS)) {
+                $valence = (float) Config::SPECIAL_CASE_IDIOMS[$zeroonetwo];
+            }
+        }
+
+        // Booster/dampener n-grams such as "sort of" or "kind of" — applied once
+        // per matching n-gram, not once per sequence-loop iteration as before.
+        foreach ([$threetwoone, $threetwo, $twoone] as $nGram) {
+            if (array_key_exists($nGram, Config::BOOSTER_DICT)) {
+                $valence += Config::BOOSTER_DICT[$nGram];
             }
         }
 
         return $valence;
     }
 
-    private function _never_check($wordInContext, $valance)
+    /**
+     * Mirrors _negation_check() in reference VADER.
+     *
+     * NOTE the startI === 2 branch reproduces an operator-precedence quirk in the
+     * reference: the trailing "so"/"this" test binds loosely, so it fires whether
+     * or not "never" is present. Deliberate — 3.0 targets parity with reference,
+     * quirks included.
+     *
+     * Previously this package multiplied by B_DECR (-0.293) rather than
+     * N_SCALAR (-0.74), making every negation roughly 2.5x too weak.
+     *
+     * @param array<int, string> $words
+     */
+    private function _negation_check(float $valence, array $words, int $startI, int $i): float
     {
-        //If the sentiment word is preceded by never so/this we apply a modifier
-        $neverModifier = 0;
-        if ("never" == $wordInContext[0]) {
-            $neverModifier = 1.25;
-        } else if ("never" == $wordInContext[1]) {
-            $neverModifier = 1.5;
-        }
-        //Only apply the so/this modifier when "never" was actually found. Without
-        //this guard $neverModifier stays 0 and the multiplication silently zeroes
-        //the valence of any sentiment word within two tokens of "so" or "this",
-        //so phrases like "this is good" and "so good" scored neutral.
-        if ($neverModifier != 0
-            && ("so" == $wordInContext[1] || "so"== $wordInContext[2] || "this" == $wordInContext[1] || "this" == $wordInContext[2])) {
-            $valance *= $neverModifier;
+        $lower = array_map('strtolower', $words);
+
+        if ($startI === 0 && $this->IsNegated($lower[$i - 1])) {
+            $valence *= Config::N_SCALAR;
         }
 
-        //if any of the words in context are negated words apply negative scaler
-        foreach ($wordInContext as $wordToCheck) {
-            if ($this->IsNegated($wordToCheck)) {
-                $valance *= Config::B_DECR;
+        if ($startI === 1) {
+            if ($lower[$i - 2] === "never"
+                && ($lower[$i - 1] === "so" || $lower[$i - 1] === "this")) {
+                $valence *= 1.25;
+            } elseif ($lower[$i - 2] === "without" && $lower[$i - 1] === "doubt") {
+                $valence = $valence;
+            } elseif ($this->IsNegated($lower[$i - 2])) {
+                $valence *= Config::N_SCALAR;
             }
         }
 
-        return $valance;
-    }
+        if ($startI === 2) {
+            if (($lower[$i - 3] === "never"
+                    && ($lower[$i - 2] === "so" || $lower[$i - 2] === "this"))
+                || ($lower[$i - 1] === "so" || $lower[$i - 1] === "this")) {
+                $valence *= 1.25;
+            } elseif ($lower[$i - 3] === "without"
+                && ($lower[$i - 2] === "doubt" || $lower[$i - 1] === "doubt")) {
+                $valence = $valence;
+            } elseif ($this->IsNegated($lower[$i - 3])) {
+                $valence *= Config::N_SCALAR;
+            }
+        }
 
+        return $valence;
+    }
 
     private function _punctuation_emphasis($sum_s, string $text): float
     {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -33,14 +33,14 @@ class Config
     //booster/dampener 'intensifiers' or 'degree adverbs'
     //http://en.wiktionary.org/wiki/Category:English_degree_adverbs
 
-    const BOOSTER_DICT = ["absolutely"=> self::B_INCR, "amazingly"=> self::B_INCR, "awfully"=> self::B_INCR, "completely"=> self::B_INCR, "considerably"=> self::B_INCR,
+    const BOOSTER_DICT = ["considerable"=> self::B_INCR, "exceptional"=> self::B_INCR, "extreme"=> self::B_INCR, "frackin"=> self::B_INCR, "fracking"=> self::B_INCR, "fuckin"=> self::B_INCR, "fuggin"=> self::B_INCR, "fugging"=> self::B_INCR, "incredible"=> self::B_INCR, "major"=> self::B_INCR, "marginal"=> self::B_DECR, "scarce"=> self::B_DECR, "slight"=> self::B_DECR, "total"=> self::B_INCR, "utter"=> self::B_INCR, "absolutely"=> self::B_INCR, "amazingly"=> self::B_INCR, "awfully"=> self::B_INCR, "completely"=> self::B_INCR, "considerably"=> self::B_INCR,
      "decidedly"=> self::B_INCR, "deeply"=> self::B_INCR, "effing"=> self::B_INCR,"enormous"=> self::B_INCR, "enormously"=> self::B_INCR,
      "entirely"=> self::B_INCR, "especially"=> self::B_INCR, "exceptionally"=> self::B_INCR, "extremely"=> self::B_INCR,
      "fabulously"=> self::B_INCR, "flipping"=> self::B_INCR, "flippin"=> self::B_INCR,
      "fricking"=> self::B_INCR, "frickin"=> self::B_INCR, "frigging"=> self::B_INCR, "friggin"=> self::B_INCR, "fully"=> self::B_INCR, "fucking"=> self::B_INCR,
      "greatly"=> self::B_INCR, "hella"=> self::B_INCR, "highly"=> self::B_INCR, "hugely"=> self::B_INCR, "incredibly"=> self::B_INCR,
      "intensely"=> self::B_INCR, "majorly"=> self::B_INCR, "more"=> self::B_INCR, "most"=> self::B_INCR, "particularly"=> self::B_INCR,
-     "purely"=> self::B_INCR, "quite"=> self::B_INCR, "seemingly" => self::B_INCR, "really"=> self::B_INCR, "remarkably"=> self::B_INCR,
+     "purely"=> self::B_INCR, "quite"=> self::B_INCR, "really"=> self::B_INCR, "remarkably"=> self::B_INCR,
      "so"=> self::B_INCR, "substantially"=> self::B_INCR,
      "thoroughly"=> self::B_INCR, "totally"=> self::B_INCR, "tremendous"=> self::B_INCR, "tremendously"=> self::B_INCR,
      "uber"=> self::B_INCR, "unbelievably"=> self::B_INCR, "unusually"=> self::B_INCR, "utterly"=> self::B_INCR,
@@ -60,7 +60,7 @@ class Config
                           "on the ball"=> 2, "under the weather"=> -2];
 
     // check for special case idioms using a sentiment-laden keyword known to SAGE
-    const SPECIAL_CASE_IDIOMS = ["the shit"=> 3, "the bomb"=> 3, "bad ass"=> 1.5, "bus stop"=> 0.0, "yeah right"=> -2, "cut the mustard"=> 2, "kiss of death"=> -1.5, "hand to mouth"=> -2, "beating heart"=> 3.1,"broken heart"=> -2.9,  "to die for"=> 3];
+    const SPECIAL_CASE_IDIOMS = ["the shit"=> 3, "the bomb"=> 3, "bad ass"=> 1.5, "badass"=> 1.5, "bus stop"=> 0.0, "yeah right"=> -2, "kiss of death"=> -1.5, "to die for"=> 3, "beating heart"=> 3.5];
     ##Static methods##
 
     /*

--- a/src/Procedures/SentiText.php
+++ b/src/Procedures/SentiText.php
@@ -22,6 +22,9 @@ class SentiText
     const PUNC_LIST = [".", "!", "?", ",", ";", ":", "-", "'", "\"",
              "!!", "!!!", "??", "???", "?!?", "!?!", "?!?!", "!?!?"];
 
+    /** Python's string.punctuation, used for token trimming. */
+    const PUNCTUATION = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+
 
     public function __construct(string $text)
     {
@@ -48,24 +51,6 @@ class SentiText
     }
 
     /*
-        Remove all punctation from a string
-    */
-    public function strip_punctuation(string $string): string
-    {
-        //$string = strtolower($string);
-        return preg_replace("/[[:punct:]]+/", "", $string);
-    }
-
-    public function array_count_values_of(array $haystack, string $needle): int
-    {
-        if (!in_array($needle, $haystack, true)) {
-            return 0;
-        }
-        $counts = array_count_values($haystack);
-        return $counts[$needle];
-    }
-
-    /*
         Check whether just some words in the input are ALL CAPS
 
         :param list words: The words to inspect
@@ -89,56 +74,43 @@ class SentiText
         return $is_different;
     }
 
-    public function _words_only(): array
-    {
-        $text_mod = $this->strip_punctuation($this->text);
-        // removes punctuation (but loses emoticons & contractions)
-        $words_only = preg_split('/\s+/', $text_mod);
-        # get rid of empty items or single letter "words" like 'a' and 'I'
-        $works_only = array_filter($words_only, function ($word) {
-            return strlen($word) > 1;
-        });
-        return $words_only;
-    }
-
+    /**
+     * Mirrors SentiText._words_and_emoticons() in reference VADER.
+     *
+     * Split on whitespace, then strip leading/trailing punctuation from each
+     * token — unless what remains is two characters or fewer, which means the
+     * token was probably an emoticon and is kept intact.
+     *
+     * The previous implementation dropped every single-character token and only
+     * stripped punctuation runs that appeared literally in PUNC_LIST. That
+     * shifted token indices (breaking every position-dependent rule) and left
+     * "good!!!!" untokenized, scoring it 0.0000.
+     *
+     * @return array<int, string>
+     */
     public function _words_and_emoticons(): array
     {
+        $tokens = preg_split('/\s+/u', trim($this->text), -1, PREG_SPLIT_NO_EMPTY);
 
-        $wes = preg_split('/\s+/', $this->text);
-
-        # get rid of residual empty items or single letter words
-        $wes = array_filter($wes, function ($word) {
-            return strlen($word) > 1;
-        });
-        //Need to remap the indexes of the array
-        $wes = array_values($wes);
-        $words_only = $this->_words_only();
-
-        foreach ($words_only as $word) {
-            foreach (self::PUNC_LIST as $punct) {
-                //replace all punct + word combinations with word
-                $pword = $punct .$word;
-
-
-                $x1 = $this->array_count_values_of($wes, $pword);
-                while ($x1 > 0) {
-                    $i = array_search($pword, $wes, true);
-                    unset($wes[$i]);
-                    array_splice($wes, $i, 0, $word);
-                    $x1 = $this->array_count_values_of($wes, $pword);
-                }
-                //Do the same as above but word then punct
-                $wordp = $word . $punct;
-                $x2 = $this->array_count_values_of($wes, $wordp);
-                while ($x2 > 0) {
-                    $i = array_search($wordp, $wes, true);
-                    unset($wes[$i]);
-                    array_splice($wes, $i, 0, $word);
-                    $x2 = $this->array_count_values_of($wes, $wordp);
-                }
-            }
+        if ($tokens === false) {
+            return [];
         }
 
-        return $wes;
+        return array_map([$this, 'stripPuncIfWord'], $tokens);
+    }
+
+    /**
+     * Python's str.strip(string.punctuation) equivalent, with the reference's
+     * "<= 2 characters means it was an emoticon" guard.
+     */
+    private function stripPuncIfWord(string $token): string
+    {
+        $stripped = trim($token, self::PUNCTUATION);
+
+        if (mb_strlen($stripped, 'UTF-8') <= 2) {
+            return $token;
+        }
+
+        return $stripped;
     }
 }

--- a/tests/fixtures/baseline.json
+++ b/tests/fixtures/baseline.json
@@ -2,492 +2,590 @@
     "booster/absolutely": {
         "text": "absolutely good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/almost": {
         "text": "almost good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/amazingly": {
         "text": "amazingly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/awfully": {
         "text": "awfully good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/barely": {
         "text": "barely good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/completely": {
         "text": "completely good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/considerable": {
+        "text": "considerable good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/considerably": {
         "text": "considerably good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/decidedly": {
         "text": "decidedly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/deeply": {
         "text": "deeply good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/effing": {
         "text": "effing good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/enormous": {
         "text": "enormous good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/enormously": {
         "text": "enormously good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/entirely": {
         "text": "entirely good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/especially": {
         "text": "especially good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/exceptional": {
+        "text": "exceptional good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/exceptionally": {
         "text": "exceptionally good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/extreme": {
+        "text": "extreme good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/extremely": {
         "text": "extremely good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/fabulously": {
         "text": "fabulously good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/flippin": {
         "text": "flippin good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/flipping": {
         "text": "flipping good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/frackin": {
+        "text": "frackin good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/fracking": {
+        "text": "fracking good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/frickin": {
         "text": "frickin good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/fricking": {
         "text": "fricking good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/friggin": {
         "text": "friggin good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/frigging": {
         "text": "frigging good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/fuckin": {
+        "text": "fuckin good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/fucking": {
         "text": "fucking good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/fuggin": {
+        "text": "fuggin good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/fugging": {
+        "text": "fugging good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/fully": {
         "text": "fully good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/greatly": {
         "text": "greatly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/hardly": {
         "text": "hardly good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/hella": {
         "text": "hella good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/highly": {
         "text": "highly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/hugely": {
         "text": "hugely good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/incredible": {
+        "text": "incredible good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/incredibly": {
         "text": "incredibly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/intensely": {
         "text": "intensely good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/just enough": {
         "text": "just enough good",
         "neg": "0.000",
-        "neu": "0.582",
-        "pos": "0.418",
-        "compound": "0.1116"
+        "neu": "0.408",
+        "pos": "0.592",
+        "compound": "0.4404"
     },
     "booster/kind of": {
         "text": "kind of good",
         "neg": "0.000",
-        "neu": "0.582",
-        "pos": "0.418",
-        "compound": "0.1116"
+        "neu": "0.408",
+        "pos": "0.592",
+        "compound": "0.4404"
     },
     "booster/kind-of": {
         "text": "kind-of good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/kinda": {
         "text": "kinda good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/kindof": {
         "text": "kindof good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/less": {
         "text": "less good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/little": {
         "text": "little good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
+    },
+    "booster/major": {
+        "text": "major good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/majorly": {
         "text": "majorly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/marginal": {
+        "text": "marginal good",
+        "neg": "0.000",
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/marginally": {
         "text": "marginally good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/more": {
         "text": "more good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/most": {
         "text": "most good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/occasional": {
         "text": "occasional good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/occasionally": {
         "text": "occasionally good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/particularly": {
         "text": "particularly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/partly": {
         "text": "partly good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/purely": {
         "text": "purely good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/quite": {
         "text": "quite good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/really": {
         "text": "really good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/remarkably": {
         "text": "remarkably good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/scarce": {
+        "text": "scarce good",
+        "neg": "0.000",
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/scarcely": {
         "text": "scarcely good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
-    "booster/seemingly": {
-        "text": "seemingly good",
+    "booster/slight": {
+        "text": "slight good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/slightly": {
         "text": "slightly good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/so": {
         "text": "so good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/somewhat": {
         "text": "somewhat good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/sort of": {
         "text": "sort of good",
         "neg": "0.000",
-        "neu": "0.582",
-        "pos": "0.418",
-        "compound": "0.1116"
+        "neu": "0.408",
+        "pos": "0.592",
+        "compound": "0.4404"
     },
     "booster/sort-of": {
         "text": "sort-of good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/sorta": {
         "text": "sorta good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/sortof": {
         "text": "sortof good",
         "neg": "0.000",
-        "neu": "0.275",
-        "pos": "0.725",
-        "compound": "0.3892"
+        "neu": "0.277",
+        "pos": "0.723",
+        "compound": "0.3832"
     },
     "booster/substantially": {
         "text": "substantially good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/thoroughly": {
         "text": "thoroughly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/total": {
+        "text": "total good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/totally": {
         "text": "totally good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/tremendous": {
         "text": "tremendous good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/tremendously": {
         "text": "tremendously good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/uber": {
         "text": "uber good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/unbelievably": {
         "text": "unbelievably good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/unusually": {
         "text": "unusually good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
+    },
+    "booster/utter": {
+        "text": "utter good",
+        "neg": "0.000",
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/utterly": {
         "text": "utterly good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "booster/very": {
         "text": "very good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "but_clause/double": {
         "text": "good but terrible but good",
@@ -575,17 +673,17 @@
     },
     "caps/negated_lower": {
         "text": "not good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "caps/negated_upper": {
         "text": "NOT GOOD",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "caps/upper": {
         "text": "GOOD",
@@ -711,17 +809,17 @@
     },
     "edge/contraction": {
         "text": "isn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "edge/emoji_mixed": {
         "text": "This is REALLY good!!! 😁 but not terrible",
         "neg": "0.000",
-        "neu": "0.555",
-        "pos": "0.445",
-        "compound": "0.7360"
+        "neu": "0.509",
+        "pos": "0.491",
+        "compound": "0.8257"
     },
     "edge/emoji_only": {
         "text": "😁😁😁",
@@ -761,8 +859,8 @@
     "edge/long_sentence": {
         "text": "This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. This product is amazing and I love it. ",
         "neg": "0.000",
-        "neu": "0.385",
-        "pos": "0.615",
+        "neu": "0.429",
+        "pos": "0.571",
         "compound": "0.9979"
     },
     "edge/newlines": {
@@ -782,7 +880,7 @@
     "edge/numbers_only": {
         "text": "1 2 3 4 5",
         "neg": "0.000",
-        "neu": "0.000",
+        "neu": "1.000",
         "pos": "0.000",
         "compound": "0.0000"
     },
@@ -810,7 +908,7 @@
     "edge/single_char": {
         "text": "a",
         "neg": "0.000",
-        "neu": "0.000",
+        "neu": "1.000",
         "pos": "0.000",
         "compound": "0.0000"
     },
@@ -1201,17 +1299,24 @@
     },
     "idiom/bad ass": {
         "text": "bad ass",
-        "neg": "0.583",
+        "neg": "1.000",
         "neu": "0.000",
-        "pos": "0.417",
-        "compound": "-0.2500"
+        "pos": "0.000",
+        "compound": "-0.7906"
+    },
+    "idiom/badass": {
+        "text": "badass",
+        "neg": "0.000",
+        "neu": "0.000",
+        "pos": "1.000",
+        "compound": "0.3400"
     },
     "idiom/beating heart": {
         "text": "beating heart",
-        "neg": "0.423",
+        "neg": "0.417",
         "neu": "0.000",
-        "pos": "0.577",
-        "compound": "0.2732"
+        "pos": "0.583",
+        "compound": "0.2960"
     },
     "idiom/blow smoke": {
         "text": "blow smoke",
@@ -1234,19 +1339,12 @@
         "pos": "0.000",
         "compound": "0.0000"
     },
-    "idiom/broken heart": {
-        "text": "broken heart",
-        "neg": "1.000",
-        "neu": "0.000",
-        "pos": "0.000",
-        "compound": "-0.7906"
-    },
     "idiom/bus stop": {
         "text": "bus stop",
-        "neg": "0.000",
-        "neu": "1.000",
+        "neg": "0.688",
+        "neu": "0.313",
         "pos": "0.000",
-        "compound": "0.0000"
+        "compound": "-0.2960"
     },
     "idiom/cooking with gas": {
         "text": "cooking with gas",
@@ -1285,10 +1383,10 @@
     },
     "idiom/kiss of death": {
         "text": "kiss of death",
-        "neg": "0.397",
-        "neu": "0.159",
-        "pos": "0.444",
-        "compound": "0.0772"
+        "neg": "0.506",
+        "neu": "0.130",
+        "pos": "0.364",
+        "compound": "-0.2732"
     },
     "idiom/on the ball": {
         "text": "on the ball",
@@ -1299,17 +1397,17 @@
     },
     "idiom/the bomb": {
         "text": "the bomb",
-        "neg": "0.000",
-        "neu": "0.200",
-        "pos": "0.800",
-        "compound": "0.6124"
+        "neg": "0.762",
+        "neu": "0.238",
+        "pos": "0.000",
+        "compound": "-0.4939"
     },
     "idiom/the shit": {
         "text": "the shit",
-        "neg": "0.000",
-        "neu": "0.200",
-        "pos": "0.800",
-        "compound": "0.6124"
+        "neg": "0.783",
+        "neu": "0.217",
+        "pos": "0.000",
+        "compound": "-0.5574"
     },
     "idiom/to die for": {
         "text": "to die for",
@@ -1353,12 +1451,19 @@
         "pos": "0.278",
         "compound": "-0.2500"
     },
+    "idiom_sentence/badass": {
+        "text": "it was badass today",
+        "neg": "0.000",
+        "neu": "0.556",
+        "pos": "0.444",
+        "compound": "0.3400"
+    },
     "idiom_sentence/beating heart": {
         "text": "it was beating heart today",
-        "neg": "0.297",
-        "neu": "0.297",
-        "pos": "0.406",
-        "compound": "0.2732"
+        "neg": "0.286",
+        "neu": "0.286",
+        "pos": "0.429",
+        "compound": "0.3612"
     },
     "idiom_sentence/blow smoke": {
         "text": "it was blow smoke today",
@@ -1380,13 +1485,6 @@
         "neu": "1.000",
         "pos": "0.000",
         "compound": "0.0000"
-    },
-    "idiom_sentence/broken heart": {
-        "text": "it was broken heart today",
-        "neg": "0.700",
-        "neu": "0.300",
-        "pos": "0.000",
-        "compound": "-0.7906"
     },
     "idiom_sentence/bus stop": {
         "text": "it was bus stop today",
@@ -1489,30 +1587,30 @@
     "kind_of/kind_bare": {
         "text": "kind",
         "neg": "0.000",
-        "neu": "1.000",
-        "pos": "0.000",
-        "compound": "0.0000"
+        "neu": "0.000",
+        "pos": "1.000",
+        "compound": "0.5267"
     },
     "kind_of/kind_of_good": {
         "text": "kind of good",
         "neg": "0.000",
-        "neu": "0.582",
-        "pos": "0.418",
-        "compound": "0.1116"
+        "neu": "0.408",
+        "pos": "0.592",
+        "compound": "0.4404"
     },
     "kind_of/kind_person": {
         "text": "he is a kind person",
         "neg": "0.000",
-        "neu": "1.000",
-        "pos": "0.000",
-        "compound": "0.0000"
+        "neu": "0.541",
+        "pos": "0.459",
+        "compound": "0.5267"
     },
     "kind_of/sort_of_good": {
         "text": "sort of good",
         "neg": "0.000",
-        "neu": "0.582",
-        "pos": "0.418",
-        "compound": "0.1116"
+        "neu": "0.408",
+        "pos": "0.592",
+        "compound": "0.4404"
     },
     "least_never/at_least": {
         "text": "at least it works",
@@ -1537,38 +1635,38 @@
     },
     "least_never/never_bare": {
         "text": "never good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "least_never/never_sentence": {
         "text": "I have never been so happy",
-        "neg": "0.343",
-        "neu": "0.657",
-        "pos": "0.000",
-        "compound": "-0.2699"
+        "neg": "0.000",
+        "neu": "0.513",
+        "pos": "0.487",
+        "compound": "0.6948"
     },
     "least_never/never_so": {
         "text": "never so good",
-        "neg": "0.494",
-        "neu": "0.506",
-        "pos": "0.000",
-        "compound": "-0.2385"
+        "neg": "0.000",
+        "neu": "0.348",
+        "pos": "0.652",
+        "compound": "0.5777"
     },
     "least_never/never_this": {
         "text": "never this good",
-        "neg": "0.478",
-        "neu": "0.522",
-        "pos": "0.000",
-        "compound": "-0.2108"
+        "neg": "0.000",
+        "neu": "0.372",
+        "pos": "0.628",
+        "compound": "0.5228"
     },
     "least_never/without_doubt": {
         "text": "without doubt good",
-        "neg": "0.390",
-        "neu": "0.250",
-        "pos": "0.360",
-        "compound": "-0.0302"
+        "neg": "0.000",
+        "neu": "0.166",
+        "pos": "0.834",
+        "compound": "0.6136"
     },
     "lexicon/=|": {
         "text": "=|",
@@ -1852,416 +1950,416 @@
     },
     "negation/ain't": {
         "text": "ain't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/aint": {
         "text": "aint good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/aren't": {
         "text": "aren't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/arent": {
         "text": "arent good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/can't": {
         "text": "can't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/cannot": {
         "text": "cannot good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/cant": {
         "text": "cant good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/couldn't": {
         "text": "couldn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/couldnt": {
         "text": "couldnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/daren't": {
         "text": "daren't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/darent": {
         "text": "darent good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/despite": {
         "text": "despite good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/didn't": {
         "text": "didn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/didnt": {
         "text": "didnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/doesn't": {
         "text": "doesn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/doesnt": {
         "text": "doesnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/don't": {
         "text": "don't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/dont": {
         "text": "dont good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/hadn't": {
         "text": "hadn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/hadnt": {
         "text": "hadnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/hasn't": {
         "text": "hasn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/hasnt": {
         "text": "hasnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/haven't": {
         "text": "haven't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/havent": {
         "text": "havent good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/isn't": {
         "text": "isn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/isnt": {
         "text": "isnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/mightn't": {
         "text": "mightn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/mightnt": {
         "text": "mightnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/mustn't": {
         "text": "mustn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/mustnt": {
         "text": "mustnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/needn't": {
         "text": "needn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/neednt": {
         "text": "neednt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/neither": {
         "text": "neither good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/never": {
         "text": "never good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/none": {
         "text": "none good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/nope": {
         "text": "nope good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/nor": {
         "text": "nor good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/not": {
         "text": "not good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/nothing": {
         "text": "nothing good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/nowhere": {
         "text": "nowhere good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/oughtn't": {
         "text": "oughtn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/oughtnt": {
         "text": "oughtnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/rarely": {
         "text": "rarely good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/seldom": {
         "text": "seldom good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/shan't": {
         "text": "shan't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/shant": {
         "text": "shant good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/shouldn't": {
         "text": "shouldn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/shouldnt": {
         "text": "shouldnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/uh-uh": {
         "text": "uh-uh good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/uhuh": {
         "text": "uhuh good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/wasn't": {
         "text": "wasn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/wasnt": {
         "text": "wasnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/weren't": {
         "text": "weren't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/werent": {
         "text": "werent good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/without": {
         "text": "without good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/won't": {
         "text": "won't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/wont": {
         "text": "wont good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/wouldn't": {
         "text": "wouldn't good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "negation/wouldnt": {
         "text": "wouldnt good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "never_check/control_good": {
         "text": "good",
@@ -2286,24 +2384,24 @@
     },
     "never_check/never_good": {
         "text": "never good",
-        "neg": "0.609",
-        "neu": "0.391",
+        "neg": "0.706",
+        "neu": "0.294",
         "pos": "0.000",
-        "compound": "-0.1423"
+        "compound": "-0.3412"
     },
     "never_check/never_so_good": {
         "text": "never so good",
-        "neg": "0.494",
-        "neu": "0.506",
-        "pos": "0.000",
-        "compound": "-0.2385"
+        "neg": "0.000",
+        "neu": "0.348",
+        "pos": "0.652",
+        "compound": "0.5777"
     },
     "never_check/never_this_good": {
         "text": "never this good",
-        "neg": "0.478",
-        "neu": "0.522",
-        "pos": "0.000",
-        "compound": "-0.2108"
+        "neg": "0.000",
+        "neu": "0.372",
+        "pos": "0.628",
+        "compound": "0.5228"
     },
     "never_check/so_far_amazing": {
         "text": "so the cake looks amazing",
@@ -2315,16 +2413,16 @@
     "never_check/so_good": {
         "text": "so good",
         "neg": "0.000",
-        "neu": "0.240",
-        "pos": "0.760",
-        "compound": "0.4877"
+        "neu": "0.238",
+        "pos": "0.762",
+        "compound": "0.4927"
     },
     "never_check/so_is_good": {
         "text": "so it is good",
         "neg": "0.000",
-        "neu": "0.484",
-        "pos": "0.516",
-        "compound": "0.4927"
+        "neu": "0.487",
+        "pos": "0.513",
+        "compound": "0.4877"
     },
     "never_check/that_is_good": {
         "text": "that is good",
@@ -2399,9 +2497,9 @@
     "punctuation/ep4": {
         "text": "good!!!!",
         "neg": "0.000",
-        "neu": "1.000",
-        "pos": "0.000",
-        "compound": "0.0000"
+        "neu": "0.000",
+        "pos": "1.000",
+        "compound": "0.6209"
     },
     "punctuation/mixed": {
         "text": "good?!?!",
@@ -2441,9 +2539,9 @@
     "punctuation/qm4": {
         "text": "good????",
         "neg": "0.000",
-        "neu": "1.000",
-        "pos": "0.000",
-        "compound": "0.0000"
+        "neu": "0.000",
+        "pos": "1.000",
+        "compound": "0.5940"
     },
     "readme/simple_emoji": {
         "text": "😁",
@@ -2473,10 +2571,10 @@
             "mediocre": "-1.0",
             "agressive": "-0.5"
         },
-        "neg": "0.338",
-        "neu": "0.662",
+        "neg": "0.310",
+        "neu": "0.690",
         "pos": "0.000",
-        "compound": "-0.2598"
+        "compound": "-0.2006"
     },
     "readme_advanced/amazing": {
         "text": "This cake looks amazing",
@@ -2498,8 +2596,8 @@
             "agressive": "-0.5"
         },
         "neg": "0.000",
-        "neu": "0.761",
-        "pos": "0.239",
+        "neu": "0.769",
+        "pos": "0.231",
         "compound": "0.7650"
     },
     "readme_advanced/mediocre": {
@@ -2534,9 +2632,9 @@
             "agressive": "-0.5"
         },
         "neg": "0.000",
-        "neu": "0.457",
-        "pos": "0.543",
-        "compound": "0.5520"
+        "neu": "0.455",
+        "pos": "0.545",
+        "compound": "0.5563"
     },
     "readme_advanced/to_be": {
         "text": "To be or not to be?",

--- a/tools/conformance.sh
+++ b/tools/conformance.sh
@@ -10,18 +10,37 @@
 # guarantees byte-identical scores with 1.3.0. The `v1!=v2` column is therefore a
 # regression alarm — any non-zero value means the two lines have drifted.
 #
-# INFORMATIONAL ONLY. Always exits 0, and is deliberately NOT wired into CI:
-# it measures a known, accepted gap, and gating builds on a number we have
-# consciously chosen not to fix yet would block every build.
+# From 3.0.0 this is a GATE, not a report: the package is a faithful port and
+# conformance is expected to be 0. Any divergence fails the run. Pass
+# --allow-divergence to report without failing (useful mid-refactor).
 #
-# Usage: ./tools/conformance.sh   (or: composer conformance)
+# Usage: ./tools/conformance.sh              compare committed branches
+#        ./tools/conformance.sh --worktree   score v2 from the working tree
+#
+# --worktree is what you want while actively changing the scoring engine:
+# without it the v2 column reflects the last commit, not your edits.
 
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURE="$PROJECT_DIR/tests/fixtures/baseline.json"
+# Pinned deliberately: SPECIAL_CASES differs between vaderSentiment releases
+# (3.3.2 has "beating heart" => 3.5 and no "broken heart"; the GitHub master
+# source has 3.1 and -2.9). Conformance is only meaningful against a fixed target.
+VADER_VERSION="${VADER_VERSION:-3.3.2}"
 V1_REF="${CONFORMANCE_V1_REF:-1.x}"
 V2_REF="${CONFORMANCE_V2_REF:-master}"
+USE_WORKTREE=0
+ALLOW_DIVERGENCE=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --worktree) USE_WORKTREE=1 ;;
+        --allow-divergence) ALLOW_DIVERGENCE=1 ;;
+        -h|--help) sed -n '2,12p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "ERROR: unknown argument '$arg' (expected --worktree or --allow-divergence)"; exit 2 ;;
+    esac
+done
 
 cd "$PROJECT_DIR"
 
@@ -76,17 +95,34 @@ PHP
 score_branch() {
     local ref="$1" out="$2" stage="$WORK/src-$3"
     mkdir -p "$stage"
-    git archive "$ref" src | tar -xf - -C "$stage"
+    if [ "$ref" = "WORKTREE" ]; then
+        tar -cf - src | tar -xf - -C "$stage"
+    else
+        git archive "$ref" src | tar -xf - -C "$stage"
+    fi
     docker run --rm --user "$(id -u):$(id -g)" \
         -v "$WORK":/w -v "$stage":/stage -w /w \
         -e SRC_ROOT=/stage -e "OUT_FILE=/w/$out" \
         php:8.1-cli php /w/score.php
 }
 
-printf '\n  scoring with v1 (%s)...\n' "$V1_REF"
-score_branch "$V1_REF" "v1.json" "v1"
+HAVE_V1=1
+if git rev-parse --verify --quiet "$V1_REF" >/dev/null 2>&1; then
+    printf '\n  scoring with v1 (%s)...\n' "$V1_REF"
+    score_branch "$V1_REF" "v1.json" "v1"
+else
+    # CI checkouts often lack the maintenance branch. The v1 column is a
+    # drift alarm, not the gate — carry on without it.
+    HAVE_V1=0
+    printf '\n  skipping v1 (%s not available in this checkout)\n' "$V1_REF"
+fi
 
-printf '  scoring with v2 (%s)...\n' "$V2_REF"
+if [ "$USE_WORKTREE" -eq 1 ]; then
+    V2_REF="WORKTREE"
+    printf '  scoring with v2 (working tree)...\n'
+else
+    printf '  scoring with v2 (%s)...\n' "$V2_REF"
+fi
 score_branch "$V2_REF" "v2.json" "v2"
 
 printf '  scoring with reference Python VADER...\n'
@@ -100,11 +136,15 @@ json.dump({k: f"{a.polarity_scores(t)['compound']:.4f}" for k, t in cases.items(
           open('/w/ref.json', 'w'))
 PY
 docker run --rm --user "$(id -u):$(id -g)" -v "$WORK":/w -w /w \
-    -e HOME=/tmp -e PYTHONDONTWRITEBYTECODE=1 \
-    python:3.11-slim sh -c 'pip install -q --no-cache-dir vaderSentiment >/dev/null 2>&1 && python ref.py'
+    -e HOME=/tmp -e PYTHONDONTWRITEBYTECODE=1 -e VADER_VERSION="$VADER_VERSION" \
+    python:3.11-slim sh -c 'pip install -q --no-cache-dir "vaderSentiment==${VADER_VERSION}" >/dev/null 2>&1 && python ref.py'
 
-REF_VERSION="$(docker run --rm python:3.11-slim sh -c \
-    'pip install -q --no-cache-dir vaderSentiment >/dev/null 2>&1 && pip show vaderSentiment 2>/dev/null | awk "/^Version/{print \$2}"' || echo '?')"
+REF_VERSION="$(docker run --rm -e VADER_VERSION="$VADER_VERSION" python:3.11-slim sh -c \
+    'pip install -q --no-cache-dir "vaderSentiment==${VADER_VERSION}" >/dev/null 2>&1 && pip show vaderSentiment 2>/dev/null | awk "/^Version/{print \$2}"' || echo '?')"
+
+if [ "$HAVE_V1" -eq 0 ]; then
+    cp "$WORK/v2.json" "$WORK/v1.json"
+fi
 
 php -r '
 $v1  = json_decode(file_get_contents($argv[1]), true);
@@ -133,9 +173,12 @@ printf("  %s\n", str_repeat("-", 54));
 printf("  %-18s %8d %8d %8d %7d\n", "TOTAL", $t["v1"], $t["v2"], $t["drift"], $t["total"]);
 printf("\n  v2 matches reference on %d of %d cases (%.0f%% divergent)\n",
     $t["total"] - $t["v2"], $t["total"], 100 * $t["v2"] / $t["total"]);
+file_put_contents($argv[4], (string) $t["v2"]);
 
-if ($t["drift"] === 0) {
-    printf("  v1 and v2 agree on every case — the 1.3.0/2.0.0 parity guarantee holds.\n");
+if ($argv[5] === "0") {
+    printf("  (v1 column omitted — maintenance branch not present in this checkout)\n");
+} elseif ($t["drift"] === 0) {
+    printf("  v1 and v2 agree on every case.\n");
 } else {
     printf("  WARNING: v1 and v2 disagree on %d cases. The lines have drifted.\n", $t["drift"]);
 }
@@ -152,7 +195,15 @@ foreach ($rows as $k => $d) {
     if ($i++ >= 8) { break; }
     printf("    %-26s php=%-9s ref=%-9s delta=%.4f\n", $k, $v2[$k], $ref[$k], $d);
 }
-' "$WORK/v1.json" "$WORK/v2.json" "$WORK/ref.json"
+' "$WORK/v1.json" "$WORK/v2.json" "$WORK/ref.json" "$WORK/divergent" "$HAVE_V1"
 
 printf "\n  reference: Python vaderSentiment %s\n" "$REF_VERSION"
-printf "  informational only — this does not gate CI\n\n"
+
+DIVERGENT="$(cat "$WORK/divergent" 2>/dev/null || echo 0)"
+
+if [ "$DIVERGENT" -ne 0 ] && [ "$ALLOW_DIVERGENCE" -eq 0 ]; then
+    printf "  FAIL: %s case(s) diverge from reference. 3.x targets exact parity.\n\n" "$DIVERGENT"
+    exit 1
+fi
+
+printf "  conformance: OK\n\n"


### PR DESCRIPTION
Rewrites the scoring engine as a faithful port of reference Python
`vaderSentiment` 3.3.2. **`composer conformance` goes from 158 divergent cases
to 0**, and becomes a failing CI gate.

**This changes scores** — 157 of 352 shared test cases moved (~45%). That is the
point of the release, and why it is a major version.

## What this closes

2.0.1 measured the package against reference VADER for the first time and found
**47% of cases diverged**, then committed to fixing it in a major release. This
is that release.

```
  section             v1!=ref  v2!=ref   v1!=v2   total
  ------------------------------------------------------
  negation                 59        0       59      59
  booster                  70        0       70      70
  idiom                     7        0        7      21
  least_never               5        0        5       8
  never_check               5        0        5      14
  kind_of                   4        0        4       4
  ...
  ------------------------------------------------------
  TOTAL                   170        0      170     350

  v2 matches reference on 350 of 350 cases (0% divergent)
  conformance: OK
```

## Root causes fixed

The divergences were structural, not a list of bugs — which is why the loop was
rewritten rather than patched:

- **Negation** used `B_DECR (−0.293)` where VADER specifies `N_SCALAR (−0.74)`.
  Every negation was ~2.5× too weak; the package systematically under-detected
  negative sentiment. `"aint good"`: −0.1423 → **−0.3412**.
- **Booster damping** was applied by array position against a `[i−3 … i]` window,
  so the *nearest* modifier was damped most — exactly backwards.
- **The tokenizer** dropped single-character tokens, shifting every index and
  with it every position-dependent rule, and only stripped punctuation runs
  present literally in `PUNC_LIST`. `"good!!!!"` scored **0.0000**.
- **`"kind"`/`"of"`** were skipped as tokens outright; reference skips `"kind"`
  only when followed by `"of"`. `"he is a kind person"` scored **0.0000**.
- **Idiom checks** ran unconditionally instead of only at `start_i == 2`, and the
  booster n-gram was applied up to five times per token.
- **`"no"` handling** was absent; **`_least_check`** lacked its lexicon gate.
- **Config tables diverged**: `BOOSTER_DICT` was missing 15 entries and carried a
  non-upstream one (`seemingly`); `SPECIAL_CASE_IDIOMS` didn't match 3.3.2.

## Two things worth reviewer attention

**The reference version is pinned.** `SPECIAL_CASES` differs between
vaderSentiment releases — 3.3.2 has `"beating heart" => 3.5` and no
`"broken heart"`, while GitHub master has `3.1` and `−2.9`. I initially aligned
against the master source and two cases refused to converge; the harness now
pins `vaderSentiment==3.3.2`, since conformance against a moving target is
meaningless.

**Faithful means reproducing upstream's quirks**, not improving on them:
`SENTIMENT_LADEN_IDIOMS` stays unimplemented, idioms only fire at index ≥ 3, and
an operator-precedence oddity in `_negation_check` is preserved. Deviating would
make the 0-divergence gate unreachable.

## API is untouched

`ApiContractTest` passes **unmodified** through the entire rewrite —
`getSentiment()`, `updateLexicon()`, the constructor, and the v2 API all behave
exactly as before. Only the numbers changed.

## Also in this PR

- `composer conformance` is now a **gate**: exits non-zero on any divergence,
  wired into CI. Verified in both directions — it fails against a different
  reference version and passes against the pinned one.
- `2.x` added to CI triggers (cut and pushed as a maintenance branch before this
  lands, so users needing score stability have somewhere supported to sit).
- Seven private methods of dead scaffolding removed, plus three `SentiText`
  helpers that existed only for the old tokenizer.
- The package description again claims VADER equivalence — 2.0.1 had to scope
  that back; it is true again.

## Verification

- `composer conformance` — **0 / 350**, on the committed branch, not just the
  working tree
- `composer test` — 778 tests green
- `composer matrix` and `--fresh` — green on PHP 8.1/8.2/8.3/8.4 with an
  identical baseline
- `composer stan` — clean at level 5
- Every documented number computed from live output, including the README
  examples (three had gone stale again)


**Migration:** [MIGRATION.md](MIGRATION.md) has the 2.x → 3.0 section with the
before/after table and re-score guidance.
